### PR TITLE
Speed up STV

### DIFF
--- a/src/votekit/election_types.py
+++ b/src/votekit/election_types.py
@@ -4,8 +4,8 @@ from .election_state import ElectionState
 from typing import Callable, Optional
 import random
 from fractions import Fraction
-from copy import deepcopy
 from collections import namedtuple
+import pickle
 
 
 class STV:
@@ -336,7 +336,7 @@ def remove_cand(removed_cand: str, ballots: list[Ballot]) -> list[Ballot]:
     """
     Removes candidate from ranking of the ballots
     """
-    update = deepcopy(ballots)
+    update = pickle.loads(pickle.dumps(ballots, -1))
 
     for n, ballot in enumerate(update):
         new_ranking = [


### PR DESCRIPTION
The bottleneck here is `remove_cand()`, which had been `deepcopy`ing the list of ballots. We switch to using the `pickle` module instead of `deepcopy` because it's quicker. For the future, if we can figure out a way to not copy all the ballots, that would speed things up even more.