### PR TITLE
Ballot graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ htmlcov/
 .DS_Store
 dist/
 .ipynb_checkpoints
-
+.idea

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -8,7 +8,7 @@ from functools import cache
 
 class BallotGraph(Graph):
     """
-    Class to build graphs for elections with possible incomplete ballots
+    Class to build ballot graphs.
 
     **Attributes**
 
@@ -16,8 +16,10 @@ class BallotGraph(Graph):
     :   data to create graph from, either PreferenceProfile object, number of
             candidates, or list of candidates
 
-    `complete`
-    :   if True, builds complete graph, else builds incomplete (boolean)
+    `allow_partial`
+    :   if True, builds graph using all possible ballots,
+        if False, only uses total linear ordered ballots
+        if building from a PreferenceProfile, defaults to True
 
     **Methods**
     """
@@ -25,16 +27,17 @@ class BallotGraph(Graph):
     def __init__(
         self,
         source: Union[PreferenceProfile, int, list],
-        complete: Optional[bool] = True,
+        allow_partial: Optional[bool] = True,
     ):
         super().__init__()
 
         self.profile = None
         self.candidates = None
+        self.allow_partial = allow_partial
 
         if isinstance(source, int):
-            self.graph = self.build_graph(source)
             self.num_cands = source
+            self.graph = self.build_graph(source)
 
         if isinstance(source, list):
             self.num_cands = len(source)
@@ -45,14 +48,20 @@ class BallotGraph(Graph):
             self.profile = source
             self.num_voters = source.num_ballots()
             self.num_cands = len(source.get_candidates())
+            self.allow_partial = True
             if not self.graph:
                 self.graph = self.build_graph(len(source.get_candidates()))
-            self.graph = self.from_profile(source, complete)
+            self.graph = self.from_profile(source)
 
-        if not self.node_data:
-            self.node_data = {ballot: 0 for ballot in self.graph.nodes}
+        self.num_voters = sum(self.node_weights.values())
 
-        self.num_voters = sum(self.node_data.values())
+        # if no partial ballots allowed, create induced subgraph
+        if not self.allow_partial:
+            total_ballots = [n for n in self.graph.nodes() if len(n) == self.num_cands]
+            self.graph = self.graph.subgraph(total_ballots)
+
+        if not self.node_weights:
+            self.node_weights = {ballot: 0 for ballot in self.graph.nodes}
 
     def _relabel(self, gr: nx.Graph, new_label: int, num_cands: int) -> nx.Graph:
         """
@@ -120,7 +129,7 @@ class BallotGraph(Graph):
         return Gc
 
     def from_profile(
-        self, profile: PreferenceProfile, complete: Optional[bool] = True
+        self, profile: PreferenceProfile
     ) -> nx.Graph:
         """
         Updates existing graph based on cast ballots from a PreferenceProfile,
@@ -128,10 +137,11 @@ class BallotGraph(Graph):
 
         Args:
             profile: PreferenceProfile assigned to graph
-            complete: If True, builds complete graph
+
 
         Returns:
-            Complete or incomplete graph based on PrefreneceProfile
+            Graph based on PreferenceProfile, 'cast' node attribute indicates
+                    ballots cast in PreferenceProfile
         """
         if not self.profile:
             self.profile = profile
@@ -142,7 +152,7 @@ class BallotGraph(Graph):
         self.candidates = profile.get_candidates()
         ballots = profile.get_ballots()
         self.cand_num = self._number_cands(tuple(self.candidates))
-        self.node_data = {ballot: 0 for ballot in self.graph.nodes}
+        self.node_weights = {ballot: 0 for ballot in self.graph.nodes}
 
         for ballot in ballots:
             ballot_node = []
@@ -161,19 +171,7 @@ class BallotGraph(Graph):
             if tuple(ballot_node) in self.graph.nodes:
                 self.graph.nodes[tuple(ballot_node)]["weight"] += ballot.weight
                 self.graph.nodes[tuple(ballot_node)]["cast"] = True
-                self.node_data[tuple(ballot_node)] += ballot.weight
-
-        if not complete:
-            partial = nx.Graph()
-            for node in self.graph.nodes:
-                if self.graph.nodes[node]["cast"]:
-                    partial.add_node(
-                        node,
-                        weight=self.graph.nodes[node]["weight"],
-                        cast=self.graph.nodes[node]["cast"],
-                    )
-
-            self.graph = partial
+                self.node_weights[tuple(ballot_node)] += ballot.weight
 
         return self.graph
 
@@ -214,13 +212,17 @@ class BallotGraph(Graph):
 
         return legend
 
-    def draw(self, neighborhoods: Optional[dict] = {}, labels: Optional[bool] = False):
+    def draw(self, neighborhoods: Optional[dict] = {},
+             labels: Optional[bool] = False,
+             show_cast: Optional[bool] = False):
         """
         Visualize the whole election or select neighborhoods in the election.
 
         Args:
             neighborhoods: Section of graph to draw
             labels: If True, labels nodes with candidate names
+            show_cast: If True, show only nodes with "cast" attribute = True
+                        If False, show all nodes
         """
         # TODO: change this so that neighborhoods can have any neighborhood
         # not just heavy balls, also there's something wrong with the shades
@@ -231,11 +233,19 @@ class BallotGraph(Graph):
 
         k = len(neighborhoods) if neighborhoods else self.num_cands
         if k > len(COLOR_LIST):
-            raise ValueError("Number of neighborhoods exceeds colors for plotting")
+            if neighborhoods:
+                raise ValueError("Number of neighborhoods exceeds colors for plotting")
+            else:
+                raise ValueError("Number of candidates exceeds colors for plotting")
         cols = COLOR_LIST[:k]
 
         # self._clean()
-        for ballot in Gc.nodes:
+        if show_cast:
+            ballots = [n for n, data in Gc.nodes(data=True) if data["cast"]]
+        else:
+            ballots = Gc.nodes
+
+        for ballot in ballots:
             i = -1
             color: tuple = GREY
 
@@ -245,12 +255,14 @@ class BallotGraph(Graph):
                     if ballot in neighbors:
                         i = (list(neighborhoods.keys())).index(center)
                         break
-            elif self.node_data[ballot] != 0 and self.profile:
+
+            elif self.node_weights[ballot] != 0 and self.profile:
                 print(ballot)
                 i = (list(self.cand_num.values())).index(ballot[0])
 
             if "weight" in ballot:
                 color = tuple(ballot.weight * x for x in cols[i])
+
             node_cols.append(color)
 
         if labels:
@@ -261,7 +273,12 @@ class BallotGraph(Graph):
             elif self.profile:
                 node_labels = self.label_cands(self.profile.get_candidates())
 
-        nx.draw_networkx(Gc, with_labels=True, node_color=node_cols, labels=node_labels)
+        if show_cast:
+            subgraph = Gc.subgraph(ballots)
+            nx.draw_networkx(subgraph, with_labels=True, node_color=node_cols, labels=node_labels)
+
+        else:
+            nx.draw_networkx(Gc, with_labels=True, node_color=node_cols, labels=node_labels)
 
     # what are these functions supposed to do?
     # def compare(self, new_pref: PreferenceProfile, dist_type: Callable):

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -183,9 +183,13 @@ class BallotGraph(Graph):
 
         return ballot + list(missing)
 
-    def label_cands(self, candidates):
+    def label_cands(self, candidates,
+                    show_cast: Optional[bool] = False):
         """
         Assigns candidate labels to ballot graph for plotting
+
+        Args:
+            show_cast: if True, only gives labels for ballots cast in PrefProfile
         """
 
         candidate_numbers = self._number_cands(tuple(candidates))
@@ -194,10 +198,11 @@ class BallotGraph(Graph):
 
         cand_labels = {}
         for node in self.graph.nodes:
-            ballot = []
-            for num in node:
-                ballot.append(cand_dict[num])
-            cand_labels[node] = tuple(ballot)
+            if (show_cast and self.graph.nodes[node]['cast']) or not show_cast:
+                    ballot = []
+                    for num in node:
+                        ballot.append(cand_dict[num])
+                    cand_labels[node] = tuple(ballot)
 
         return cand_labels
 
@@ -257,7 +262,7 @@ class BallotGraph(Graph):
                         break
 
             elif self.node_weights[ballot] != 0 and self.profile:
-                print(ballot)
+                # print(ballot)
                 i = (list(self.cand_num.values())).index(ballot[0])
 
             if "weight" in ballot:
@@ -269,9 +274,9 @@ class BallotGraph(Graph):
             if not self.candidates:
                 raise ValueError("no candidate names assigned")
             if self.candidates:
-                node_labels = self.label_cands(self.candidates)
+                node_labels = self.label_cands(self.candidates, show_cast)
             elif self.profile:
-                node_labels = self.label_cands(self.profile.get_candidates())
+                node_labels = self.label_cands(self.profile.get_candidates(), show_cast)
 
         if show_cast:
             subgraph = Gc.subgraph(ballots)

--- a/src/votekit/graphs/base_graph.py
+++ b/src/votekit/graphs/base_graph.py
@@ -11,7 +11,7 @@ class Graph(ABC):
 
     def __init__(self, graph: nx.Graph = None):
         self.graph = graph
-        self.node_data: dict = {}  # store node to avoid acessing Nx.graph
+        self.node_weights: dict = {}  # store node weights to avoid acessing Nx.graph
 
     @abstractmethod
     def build_graph(self, *args: Any, **kwargs: Any) -> nx.Graph:
@@ -37,10 +37,10 @@ class Graph(ABC):
         """Returns dict of k ball neighborhoods of
         given radius with their centers and weights
         """
-        if not self.node_data or sum(self.node_data.values()) == 0:
+        if not self.node_weights or sum(self.node_weights.values()) == 0:
             raise TypeError("no weights assigned to graph")
 
-        cast_ballots = {x for x in self.node_data.keys() if self.node_data[x] > 0}
+        cast_ballots = {x for x in self.node_weights.keys() if self.node_weights[x] > 0}
 
         max_balls = {}
 
@@ -53,7 +53,7 @@ class Graph(ABC):
                 relevant = cast_ballots.intersection(
                     set(ball.nodes)
                 )  ##cast ballots inside the ball
-                tmp = sum(self.node_data[node] for node in relevant)
+                tmp = sum(self.node_weights[node] for node in relevant)
                 if tmp > weight:
                     weight = tmp
                     max_center = center

--- a/src/votekit/metrics/distances.py
+++ b/src/votekit/metrics/distances.py
@@ -19,7 +19,7 @@ def earth_mover_dist(pp1: PreferenceProfile, pp2: PreferenceProfile) -> int:
         Earth mover distance between inputted elections
     """
     # create ballot graph
-    ballot_graph = BallotGraph(source=pp2, complete=True).graph
+    ballot_graph = BallotGraph(source=pp2).graph
     # ballot_graph = graph.from_profile(profile=pp2, complete=True)
 
     # Solving Earth Mover Distance

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -39,12 +39,10 @@ def test_add_profile():
     num_ballots = sum_weights(wprofile)
     assert num_ballots == 9
 
+def test_allow_partial():
+    three = BallotGraph(3, allow_partial=False)
+    assert len(three.graph.nodes) == 6
 
-def test_incomplete_graph_from_profile():
-    test = BallotGraph(three_cand, complete=False)
-    num_ballots = sum_weights(test.graph)
-    assert num_ballots == 9
-    assert len(test.graph.nodes) == 2
 
 
 def test_graph_labels():
@@ -61,7 +59,7 @@ def test_k_neighbors_no_weights():
 
 def test_k_neighborhoods():
     test = BallotGraph(3)
-    test.node_data = {
+    test.node_weights = {
         (1,): 4,  # fix weights
         (1, 2, 3): 3,
         (1, 3, 2): 1,


### PR DESCRIPTION
Sorry for the length and number of changes here, but I was finding the `BallotGraph` object to not really be working as intended. High level summary of changes:

1. Change `complete` parameter to `allow_partial` in `__init__`. If `allow_partial` is True, BallotGraph constructs all possible ballot types. If False, it only generates full linear orderings.
2. Add `show_cast` parameter to `draw`. This only displays nodes of the graph that have the `cast` attribute equal to True.
3. Added/replaced necessary test functions.
4. Changed `node_data` to `node_weights` since that is the only kind of data it was storing.

@jamesturk @drdeford @jgibson517 @jennjwang @ziglaser 