### PR TITLE
Ballot graph overhaul

### DIFF
--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -191,7 +191,7 @@ class BallotGraph(Graph):
         return ballot + list(missing)
 
     def label_cands(self, candidates,
-                    to_display: Union[Callable, None] = all_nodes):
+                    to_display: Callable = all_nodes):
         """
         Assigns candidate labels to ballot graph for plotting
 
@@ -228,7 +228,7 @@ class BallotGraph(Graph):
 
         return legend
 
-    def draw(self, to_display: Union[Callable, None] = all_nodes,
+    def draw(self, to_display: Callable = all_nodes,
              neighborhoods: Optional[list[tuple]] = [],
              show_cast: Optional[bool] = False,
              labels: Optional[bool] = False):

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -191,7 +191,7 @@ class BallotGraph(Graph):
         return ballot + list(missing)
 
     def label_cands(self, candidates,
-                    to_display: Optional[Callable] = None):
+                    to_display: Optional[Callable] = all_nodes):
         """
         Assigns candidate labels to ballot graph for plotting
 

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -211,7 +211,8 @@ class BallotGraph(Graph):
                         ballot.append(cand_dict[num])
                     
                     # label the ballot and give the number of votes
-                    cand_labels[node] = str(tuple(ballot))+": " + str(self.graph.nodes[node]["weight"])
+                    cand_labels[node] = str(tuple(ballot))+": " + \
+                                    str(self.graph.nodes[node]["weight"])
 
         return cand_labels
 
@@ -229,7 +230,7 @@ class BallotGraph(Graph):
     def draw(self, to_display: Optional[Callable] = None,
              neighborhoods: Optional[list[tuple]] = [],
              show_cast: Optional[bool] = False,
-            labels: Optional[bool] = False)
+             labels: Optional[bool] = False)
         """
         Visualize the graph.
 

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -5,7 +5,8 @@ import networkx as nx  # type: ignore
 from functools import cache
 from typing import Callable
 
-
+def all_nodes(node):
+    return True
 
 class BallotGraph(Graph):
     """
@@ -226,7 +227,7 @@ class BallotGraph(Graph):
 
         return legend
 
-    def draw(self, to_display: Optional[Callable] = None,
+    def draw(self, to_display: Optional[Callable] = all_nodes,
              neighborhoods: Optional[list[tuple]] = [],
              show_cast: Optional[bool] = False,
              labels: Optional[bool] = False):
@@ -242,8 +243,7 @@ class BallotGraph(Graph):
                         If False, show all nodes.
             labels: If True, labels nodes with candidate names and vote totals
         """
-        def all_nodes(node):
-            return True
+        
 
         def cast_nodes(node):
             return self.graph.nodes[node]["cast"]
@@ -255,15 +255,11 @@ class BallotGraph(Graph):
             distances = [nx.shortest_path_length(self.graph, node, x) for x in centers]
 
             return (True in [d <= r for d,r in zip(distances, radii)])
-
-
-        if not to_display:
-            to_display = all_nodes
         
         if show_cast:
             to_display = cast_nodes
 
-        if len(neighborhoods) > 0:
+        if neighborhoods:
             to_display = in_neighborhoods
 
         ballots = [n for n in self.graph.nodes if to_display(n)]

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 import networkx as nx  # type: ignore
 from functools import cache
 from typing import Callable
+import matplotlib.pyplot as plt
 
 def all_nodes(graph, node):
     return True
@@ -272,7 +273,20 @@ class BallotGraph(Graph):
             node_labels = self.label_cands(self.candidates, to_display)
             
         subgraph = self.graph.subgraph(ballots)
-        nx.draw_networkx(subgraph, with_labels=True, labels=node_labels)
+
+        pos = nx.spring_layout(subgraph)
+        nx.draw_networkx(subgraph, pos = pos, 
+                         with_labels=True, labels=node_labels)
+
+        # handles labels overlapping with margins
+        x_values, y_values = zip(*pos.values())
+        x_max, y_max = max(x_values), max(y_values)
+        x_min, y_min = min(x_values), min(y_values)
+        x_margin = (x_max - x_min) * 0.25
+        y_margin = (y_max - y_min) * 0.25
+        plt.xlim(x_min - x_margin, x_max + x_margin)
+        plt.ylim(y_min - y_margin, y_max + y_margin)
+        plt.show()
 
        
 

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -1,6 +1,5 @@
 from .base_graph import Graph
 from ..pref_profile import PreferenceProfile
-from ..utils import COLOR_LIST
 from typing import Optional, Union
 import networkx as nx  # type: ignore
 from functools import cache

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -230,7 +230,7 @@ class BallotGraph(Graph):
     def draw(self, to_display: Optional[Callable] = None,
              neighborhoods: Optional[list[tuple]] = [],
              show_cast: Optional[bool] = False,
-             labels: Optional[bool] = False)
+             labels: Optional[bool] = False):
         """
         Visualize the graph.
 

--- a/src/votekit/graphs/base_graph.py
+++ b/src/votekit/graphs/base_graph.py
@@ -11,7 +11,7 @@ class Graph(ABC):
 
     def __init__(self, graph: nx.Graph = None):
         self.graph = graph
-        self.node_data: dict = {}  # store node to avoid acessing Nx.graph
+        self.node_weights: dict = {}  # store node weights to avoid acessing Nx.graph
 
     @abstractmethod
     def build_graph(self, *args: Any, **kwargs: Any) -> nx.Graph:
@@ -37,10 +37,10 @@ class Graph(ABC):
         """Returns dict of k ball neighborhoods of
         given radius with their centers and weights
         """
-        if not self.node_data or sum(self.node_data.values()) == 0:
+        if not self.node_weights or sum(self.node_weights.values()) == 0:
             raise TypeError("no weights assigned to graph")
 
-        cast_ballots = {x for x in self.node_data.keys() if self.node_data[x] > 0}
+        cast_ballots = {x for x in self.node_weights.keys() if self.node_weights[x] > 0}
 
         max_balls = {}
 
@@ -53,7 +53,7 @@ class Graph(ABC):
                 relevant = cast_ballots.intersection(
                     set(ball.nodes)
                 )  ##cast ballots inside the ball
-                tmp = sum(self.node_data[node] for node in relevant)
+                tmp = sum(self.node_weights[node] for node in relevant)
                 if tmp > weight:
                     weight = tmp
                     max_center = center

--- a/src/votekit/metrics/distances.py
+++ b/src/votekit/metrics/distances.py
@@ -19,7 +19,7 @@ def earth_mover_dist(pp1: PreferenceProfile, pp2: PreferenceProfile) -> int:
         Earth mover distance between inputted elections
     """
     # create ballot graph
-    ballot_graph = BallotGraph(source=pp2, complete=True).graph
+    ballot_graph = BallotGraph(source=pp2).graph
     # ballot_graph = graph.from_profile(profile=pp2, complete=True)
 
     # Solving Earth Mover Distance

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -39,12 +39,10 @@ def test_add_profile():
     num_ballots = sum_weights(wprofile)
     assert num_ballots == 9
 
+def test_allow_partial():
+    three = BallotGraph(3, allow_partial=False)
+    assert len(three.graph.nodes) == 6
 
-def test_incomplete_graph_from_profile():
-    test = BallotGraph(three_cand, complete=False)
-    num_ballots = sum_weights(test.graph)
-    assert num_ballots == 9
-    assert len(test.graph.nodes) == 2
 
 
 def test_graph_labels():
@@ -61,7 +59,7 @@ def test_k_neighbors_no_weights():
 
 def test_k_neighborhoods():
     test = BallotGraph(3)
-    test.node_data = {
+    test.node_weights = {
         (1,): 4,  # fix weights
         (1, 2, 3): 3,
         (1, 3, 2): 1,


### PR DESCRIPTION
Sorry for the length and number of changes here, but I was finding the BallotGraph object to not really be working as intended. High level summary of changes:

1. Change `complete` parameter to `allow_partial` in `__init__`. If `allow_partial` is True, BallotGraph constructs all possible ballot types. If False, it only generates full linear orderings.
2. Add `fix_short` parameter to `__init__`. Gives the user the option to change ballots of length n-1 to n.
3. Add several parameters to `draw`. `to_display` lets the user specify a boolean function on nodes to be drawn. `neighborhoods` and `show_cast` are parameters that give common display functions.
4. Added/replaced necessary test functions.
5. Changed node_data to node_weights since that is the only kind of data it was storing.

@jamesturk @drdeford @jgibson517 @jennjwang @ziglaser