### PR TITLE
Ballot Generator Tutorials

### DIFF
--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "The first thing we will do is create a `PreferenceProfile` object from our csv. A preference profile is a term from the social choice literature that represents the rankings of some set of candidates from some voters. Put another way, a preference profile stores the votes from an election, and is a collection of `Ballot` objects and candidates. \n",
     "\n",
-    "We give the `load_csv` function the path to the csv file. By default, each column of the csv should correspond to a ranking of a candidate, given in decreasing order (the first column is the voters top choice, the last column their bottom choice.) There are some other optional parameters which you can read about in the documentation."
+    "We give the `load_csv` function the path to the csv file. By default, each column of the csv should correspond to a ranking of a candidate, given in decreasing order (the first column is the voters top choice, the last column their bottom choice.) There are some other optional parameters which you can read about in the documentation, like how to read a csv file that has more columns than just rankings."
    ]
   },
   {

--- a/notebooks/pref_prof_generators.ipynb
+++ b/notebooks/pref_prof_generators.ipynb
@@ -234,7 +234,7 @@
     "\n",
     "pl_profile = pl.generate_profile(number_of_ballots)\n",
     "\n",
-    "print(pl_profile.num_ballots())\n",
+    "print(\"Number of ballots:\", pl_profile.num_ballots())\n",
     "print(pl_profile)"
    ]
   },
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the number of ballots generated may not perfectly match the number we asked for. This is because the PL model tries to generate ballots in proportion with the blocs, and there is some rounding that occurs at this step."
+    "Notice that for the first time we have ties on the ballots! The notation `{'Q1', 'Q2'} (Tie)` means that these two candidates are tied for third place."
    ]
   },
   {
@@ -281,7 +281,7 @@
     "                     candidates=candidates)\n",
     "\n",
     "bt_profile = bt.generate_profile(number_of_ballots)\n",
-    "print(bt_profile.num_ballots())\n",
+    "print(\"Number of ballots:\", bt_profile.num_ballots())\n",
     "print(bt_profile)"
    ]
   },

--- a/notebooks/pref_prof_generators.ipynb
+++ b/notebooks/pref_prof_generators.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generating `PreferenceProfiles`\n",
+    "We have already seen the use of a  `PreferenceProfile` generator (the Impartial Culture Model) in the Plotting and Ballot Graph tutorials. Now, let's dive into the rest that are included in `votekit`:\n",
+    "- Impartial Culture\n",
+    "- Impartial Anonymous Culture\n",
+    "- Plackett Luce\n",
+    "- Bradley Terry\n",
+    "- Alternating Crossover\n",
+    "- OneDimSpatial\n",
+    "- Cambridge Sampler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import votekit.ballot_generator as bg\n",
+    "from votekit.plots.profile_plots import plot_summary_stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The three simplest to use are the Impartial Culture, Impartial Anonymous Culture, and 1-D spatial models. For $m$ candidates and $n$ voters, the Impartial Culture model generates `PreferenceProfiles` uniformly at random out of the $(m!)^n$ possible profiles. Remember, a `PreferenceProfile` is a tuple of length $n$ that stores a linear ranking in each slot.\n",
+    "\n",
+    "The Impartial Anonymous Culture model does the same thing, but treats profiles that are the same up to permutation of the voters as identical. That is, the profile $(A>B, B>A)$ is now identical to $(B>A, A>B)$. It's like the IAC model treats profiles as sets, rather than tuples. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = [\"A\", \"B\", \"C\"]\n",
+    "number_of_ballots = 50\n",
+    "#Impartial Culture\n",
+    "ic = bg.ImpartialCulture(candidates = candidates)\n",
+    "ic_profile = ic.generate_profile(number_of_ballots)\n",
+    "\n",
+    "#Impartial Anonymous Culture\n",
+    "iac = bg.ImpartialAnonymousCulture(candidates = candidates)\n",
+    "iac_profile = iac.generate_profile(number_of_ballots)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 1-D Spatial model assigns each candidate a random point on the real line according to the standard normal distribution. It then does the same for each voter, and then a voter ranks candidates by their distance from the voter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one_d = bg.OneDimSpatial(candidates = candidates)\n",
+    "one_d_profile = one_d.generate_profile(number_of_ballots)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use the other models, we need a bit more information than just the candidates. Suppose there are two blocs (or groups) of voters, $Q$ and $R$. The $Q$ bloc is estimated to be about 70% of the voting population, while the $R$ block is about 30%. Within each bloc there is preference for different candidates, which we record in the variable `pref_interval_by_bloc`. \n",
+    "\n",
+    "In this example, suppose each bloc has two candidates running, but there is some crossover in which some voters from bloc $Q$ actually prefer the candidates from bloc $R$. The $R$ bloc, being much more insular, does not prefer either of $Q$s candidates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = [\"Q1\", \"Q2\", \"R1\", \"R2\"]\n",
+    "\n",
+    "# presumably tells me the percent of the population in each bloc\n",
+    "bloc_voter_prop = {\"Q\": 0.7, \"R\": 0.3}\n",
+    "\n",
+    "# within each block, who prefers which candidate\n",
+    "pref_interval_by_bloc = {\n",
+    "    \"Q\": {\"Q1\": 0.4, \"Q2\": 0.3, \"R1\": 0.2, \"R2\": 0.1},\n",
+    "    \"R\": {\"Q1\": 0, \"Q2\": 0, \"R1\": 0.4, \"R2\": 0.6}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For both the Plackett-Luce and Bradley-Terry model, this is now all the information they need to generate profiles.\n",
+    "\n",
+    "For each voter, the Plackett-Luce model samples from the list of candidates without replacement according to the distribution defined by that voter's bloc in `pref_interval_by_bloc`.\n",
+    "\n",
+    "# HOW DO THEY WORK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "Fewer non-zero entries in p than size",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[1;32m/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb Cell 10\u001b[0m line \u001b[0;36m6\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39m# Plackett-Luce\u001b[39;00m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m pl \u001b[39m=\u001b[39m bg\u001b[39m.\u001b[39mPlackettLuce(pref_interval_by_bloc\u001b[39m=\u001b[39mpref_interval_by_bloc,\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m                      bloc_voter_prop\u001b[39m=\u001b[39mbloc_voter_prop, \n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m                      candidates\u001b[39m=\u001b[39mcandidates)\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m pl_profile \u001b[39m=\u001b[39m pl\u001b[39m.\u001b[39mgenerate_profile(number_of_ballots)\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m \u001b[39m# Bradley-Terry\u001b[39;00m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m bt \u001b[39m=\u001b[39m bg\u001b[39m.\u001b[39mBradleyTerry(pref_interval_by_bloc\u001b[39m=\u001b[39mpref_interval_by_bloc,\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=9'>10</a>\u001b[0m                      bloc_voter_prop\u001b[39m=\u001b[39mbloc_voter_prop, \n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=10'>11</a>\u001b[0m                      candidates\u001b[39m=\u001b[39mcandidates)\n",
+      "File \u001b[0;32m~/PycharmProjects/VoteKit/src/votekit/ballot_generator.py:382\u001b[0m, in \u001b[0;36mPlackettLuce.generate_profile\u001b[0;34m(self, number_of_ballots)\u001b[0m\n\u001b[1;32m    377\u001b[0m     cand_support_vec \u001b[39m=\u001b[39m [pref_interval_dict[cand] \u001b[39mfor\u001b[39;00m cand \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates]\n\u001b[1;32m    379\u001b[0m     \u001b[39mfor\u001b[39;00m _ \u001b[39min\u001b[39;00m \u001b[39mrange\u001b[39m(num_ballots):\n\u001b[1;32m    380\u001b[0m         \u001b[39m# generates ranking based on probability distribution of candidate support\u001b[39;00m\n\u001b[1;32m    381\u001b[0m         ballot \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\n\u001b[0;32m--> 382\u001b[0m             np\u001b[39m.\u001b[39mrandom\u001b[39m.\u001b[39mchoice(\n\u001b[1;32m    383\u001b[0m                 \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates,\n\u001b[1;32m    384\u001b[0m                 \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mballot_length,\n\u001b[1;32m    385\u001b[0m                 p\u001b[39m=\u001b[39mcand_support_vec,\n\u001b[1;32m    386\u001b[0m                 replace\u001b[39m=\u001b[39m\u001b[39mFalse\u001b[39;00m,\n\u001b[1;32m    387\u001b[0m             )\n\u001b[1;32m    388\u001b[0m         )\n\u001b[1;32m    390\u001b[0m         ballot_pool\u001b[39m.\u001b[39mappend(ballot)\n\u001b[1;32m    392\u001b[0m pp \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mballot_pool_to_profile(\n\u001b[1;32m    393\u001b[0m     ballot_pool\u001b[39m=\u001b[39mballot_pool, candidates\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates\n\u001b[1;32m    394\u001b[0m )\n",
+      "File \u001b[0;32mnumpy/random/mtrand.pyx:1007\u001b[0m, in \u001b[0;36mnumpy.random.mtrand.RandomState.choice\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: Fewer non-zero entries in p than size"
+     ]
+    }
+   ],
+   "source": [
+    "# Plackett-Luce\n",
+    "pl = bg.PlackettLuce(pref_interval_by_bloc=pref_interval_by_bloc,\n",
+    "                     bloc_voter_prop=bloc_voter_prop, \n",
+    "                     candidates=candidates)\n",
+    "\n",
+    "pl_profile = pl.generate_profile(number_of_ballots)\n",
+    "\n",
+    "# Bradley-Terry\n",
+    "bt = bg.BradleyTerry(pref_interval_by_bloc=pref_interval_by_bloc,\n",
+    "                     bloc_voter_prop=bloc_voter_prop, \n",
+    "                     candidates=candidates)\n",
+    "\n",
+    "bt_profile = bt.generate_profile(number_of_ballots)\n",
+    "\n",
+    "print(pl_profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternating Crossover\n",
+    "Cambridge Sampler"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "votekit",
+   "language": "python",
+   "name": "votekit"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/pref_prof_generators.ipynb
+++ b/notebooks/pref_prof_generators.ipynb
@@ -17,12 +17,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import votekit.ballot_generator as bg\n",
-    "from votekit.plots.profile_plots import plot_summary_stats"
+    "import votekit.ballot_generator as bg"
    ]
   },
   {
@@ -184,12 +183,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "candidates = [\"Q1\", \"Q2\", \"R1\", \"R2\"]\n",
-    "number_of_ballots = 51\n",
+    "number_of_ballots = 50\n",
     "\n",
     "bloc_voter_prop = {\"Q\": 0.7, \"R\": 0.3}\n",
     "\n",
@@ -201,30 +200,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "51\n",
+      "50\n",
       "                     Ballots  Weight\n",
-      "(R2, R1, {'Q1', 'Q2'} (Tie))      12\n",
-      "            (Q1, Q2, R1, R2)       8\n",
-      "            (R1, Q1, Q2, R2)       6\n",
+      "(R1, R2, {'Q1', 'Q2'} (Tie))       9\n",
+      "(R2, R1, {'Q1', 'Q2'} (Tie))       6\n",
+      "            (Q1, Q2, R1, R2)       5\n",
+      "            (R1, Q2, Q1, R2)       4\n",
       "            (Q1, R1, R2, Q2)       4\n",
-      "            (Q2, Q1, R1, R2)       3\n",
+      "            (Q2, Q1, R1, R2)       4\n",
       "            (Q2, R1, Q1, R2)       3\n",
-      "(R1, R2, {'Q1', 'Q2'} (Tie))       3\n",
-      "            (Q2, Q1, R2, R1)       2\n",
-      "            (Q1, R2, R1, Q2)       2\n",
-      "            (Q1, Q2, R2, R1)       2\n",
-      "            (R1, R2, Q1, Q2)       1\n",
+      "            (R1, Q1, Q2, R2)       3\n",
+      "            (R1, Q1, R2, Q2)       2\n",
+      "            (Q1, R1, Q2, R2)       2\n",
+      "            (R2, Q2, R1, Q1)       1\n",
+      "            (R1, R2, Q2, Q1)       1\n",
       "            (R2, Q2, Q1, R1)       1\n",
-      "            (R2, R1, Q1, Q2)       1\n",
-      "            (Q1, R2, Q2, R1)       1\n",
-      "            (Q2, R2, Q1, R1)       1\n"
+      "            (Q1, Q2, R2, R1)       1\n",
+      "            (Q2, R1, R2, Q1)       1\n"
      ]
     }
    ],
@@ -248,30 +247,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "51\n",
+      "659\n",
       "                     Ballots  Weight\n",
-      "(R1, R2, {'Q1', 'Q2'} (Tie))       8\n",
-      "            (Q1, Q2, R1, R2)       8\n",
-      "(R2, R1, {'Q1', 'Q2'} (Tie))       7\n",
-      "            (Q1, R1, Q2, R2)       4\n",
-      "            (Q1, Q2, R2, R1)       3\n",
-      "            (R1, Q2, Q1, R2)       3\n",
-      "            (Q2, R1, Q1, R2)       3\n",
-      "            (Q2, Q1, R1, R2)       3\n",
-      "            (R2, Q1, Q2, R1)       2\n",
-      "            (Q2, R2, Q1, R1)       2\n",
-      "            (Q2, Q1, R2, R1)       2\n",
-      "            (R2, Q1, R1, Q2)       1\n",
-      "            (Q2, R2, R1, Q1)       1\n",
-      "            (Q1, R1, R2, Q2)       1\n",
-      "            (R1, Q1, Q2, R2)       1\n"
+      "(R2, R1, {'Q1', 'Q2'} (Tie))     114\n",
+      "(R1, R2, {'Q1', 'Q2'} (Tie))      84\n",
+      "            (Q1, Q2, R1, R2)      83\n",
+      "            (Q2, Q1, R1, R2)      78\n",
+      "            (Q1, R1, Q2, R2)      48\n",
+      "            (Q2, R1, Q1, R2)      42\n",
+      "            (Q1, Q2, R2, R1)      38\n",
+      "            (R1, Q1, Q2, R2)      34\n",
+      "            (Q2, Q1, R2, R1)      30\n",
+      "            (R1, Q2, Q1, R2)      24\n",
+      "            (Q1, R1, R2, Q2)      20\n",
+      "            (Q1, R2, Q2, R1)      14\n",
+      "            (Q1, R2, R1, Q2)      12\n",
+      "            (R1, Q1, R2, Q2)       7\n",
+      "            (Q2, R2, Q1, R1)       6\n"
      ]
     }
    ],

--- a/notebooks/pref_prof_generators.ipynb
+++ b/notebooks/pref_prof_generators.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "The two simplest to use are the Impartial Culture and Impartial Anonymous Culture. For $m$ candidates and $n$ voters, the Impartial Culture model generates `PreferenceProfiles` uniformly at random out of the $(m!)^n$ possible profiles. Remember, a `PreferenceProfile` is a tuple of length $n$ that stores a linear ranking $m$ in each slot.\n",
     "\n",
-    "The Impartial Anonymous Culture model does the same thing, but treats profiles that are the same up to permutation of the voters as identical. That is, the profile $(A>B, B>A)$ is now identical to $(B>A, A>B)$. It's like the IAC model treats profiles as sets, rather than tuples. "
+    "The Impartial Anonymous Culture model works a little bit differently. When it generates ballots, it chooses a candidate support vector uniformly at random from among all possible support vectors, and then generates ballots according to that vector."
    ]
   },
   {

--- a/notebooks/pref_prof_generators.ipynb
+++ b/notebooks/pref_prof_generators.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,14 +29,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The three simplest to use are the Impartial Culture, Impartial Anonymous Culture, and 1-D spatial models. For $m$ candidates and $n$ voters, the Impartial Culture model generates `PreferenceProfiles` uniformly at random out of the $(m!)^n$ possible profiles. Remember, a `PreferenceProfile` is a tuple of length $n$ that stores a linear ranking in each slot.\n",
+    "The two simplest to use are the Impartial Culture and Impartial Anonymous Culture. For $m$ candidates and $n$ voters, the Impartial Culture model generates `PreferenceProfiles` uniformly at random out of the $(m!)^n$ possible profiles. Remember, a `PreferenceProfile` is a tuple of length $n$ that stores a linear ranking $m$ in each slot.\n",
     "\n",
     "The Impartial Anonymous Culture model does the same thing, but treats profiles that are the same up to permutation of the voters as identical. That is, the profile $(A>B, B>A)$ is now identical to $(B>A, A>B)$. It's like the IAC model treats profiles as sets, rather than tuples. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,12 +55,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Ballots Generated Using Intervals\n",
+    "\n",
+    "The following generative models all depend on the real line in some way.\n",
+    "\n",
     "The 1-D Spatial model assigns each candidate a random point on the real line according to the standard normal distribution. It then does the same for each voter, and then a voter ranks candidates by their distance from the voter."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,56 +76,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use the other models, we need a bit more information than just the candidates. Suppose there are two blocs (or groups) of voters, $Q$ and $R$. The $Q$ bloc is estimated to be about 70% of the voting population, while the $R$ block is about 30%. Within each bloc there is preference for different candidates, which we record in the variable `pref_interval_by_bloc`. \n",
+    "The Plackett-Luce and Bradley-Terry models both use the interval $[0,1]$. To use these models, we need a bit more information than just the candidates. Suppose for now that there is one type of voter (or bloc $Q$) in the state (these models can be generalized to more than one bloc, but we will start simple for now). We record the proportion of voters in this bloc in a dictionary.\n",
     "\n",
-    "In this example, suppose each bloc has two candidates running, but there is some crossover in which some voters from bloc $Q$ actually prefer the candidates from bloc $R$. The $R$ bloc, being much more insular, does not prefer either of $Q$s candidates."
+    "In the upcoming election, there are three candidates, $A$, $B$, and $C$. In general, the bloc $Q$ prefers $A$ 1/2  of the time, $B$ 1/3 of the time, and $C$ 1/6 of the time. We can visualize this as the line segment $[0,1]$, with the segment $[0,1/2]$ labeled $A$, $[1/2, 5/6]$ labeled $B$, and $[5/6,1]$ labeled $C$. Note the slight abuse of notation in using the same name for the candidates and their intervals. We store this information in a dictionary.\n",
+    "\n",
+    "\n",
+    "<!-- Suppose there are two blocs (or groups) of voters, $Q$ and $R$. The $Q$ bloc is estimated to be about 70% of the voting population, while the $R$ block is about 30%. Within each bloc there is preference for different candidates, which we record in the variable `pref_interval_by_bloc`. \n",
+    "\n",
+    "In this example, suppose each bloc has two candidates running, but there is some crossover in which some voters from bloc $Q$ actually prefer the candidates from bloc $R$. The $R$ bloc, being much more insular, does not prefer either of $Q$'s candidates. -->"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
-    "candidates = [\"Q1\", \"Q2\", \"R1\", \"R2\"]\n",
+    "candidates = [\"A\", \"B\", \"C\"]\n",
+    "number_of_ballots = 50\n",
     "\n",
-    "# presumably tells me the percent of the population in each bloc\n",
-    "bloc_voter_prop = {\"Q\": 0.7, \"R\": 0.3}\n",
+    "bloc_voter_prop = {\"Q\":1}\n",
     "\n",
-    "# within each block, who prefers which candidate\n",
-    "pref_interval_by_bloc = {\n",
-    "    \"Q\": {\"Q1\": 0.4, \"Q2\": 0.3, \"R1\": 0.2, \"R2\": 0.1},\n",
-    "    \"R\": {\"Q1\": 0, \"Q2\": 0, \"R1\": 0.4, \"R2\": 0.6}\n",
-    "}"
+    "pref_interval_by_bloc = {\"Q\" : {\"A\": 1/2, \n",
+    "                                \"B\": 1/3,\n",
+    "                                \"C\": 1/6}}\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For both the Plackett-Luce and Bradley-Terry model, this is now all the information they need to generate profiles.\n",
-    "\n",
-    "For each voter, the Plackett-Luce model samples from the list of candidates without replacement according to the distribution defined by that voter's bloc in `pref_interval_by_bloc`.\n",
-    "\n",
-    "# HOW DO THEY WORK"
+    "For each voter, the Plackett-Luce (PL) model samples from the list of candidates without replacement according to the distribution defined by the preference intervals. The first candidate it samples is in first place, then second, etc. Visualizing this as the line segment, the PL model uniformly at random selects a point in $[0,1]$. Whichever candidate's interval that point lies in is listed first in the ballot. It then removes that candidate's preference interval from $[0,1]$, rescales so the segment has length 1 again, and then samples a second candidate. Repeat until all candidates have been sampled."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "Fewer non-zero entries in p than size",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb Cell 10\u001b[0m line \u001b[0;36m6\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39m# Plackett-Luce\u001b[39;00m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m pl \u001b[39m=\u001b[39m bg\u001b[39m.\u001b[39mPlackettLuce(pref_interval_by_bloc\u001b[39m=\u001b[39mpref_interval_by_bloc,\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m                      bloc_voter_prop\u001b[39m=\u001b[39mbloc_voter_prop, \n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m                      candidates\u001b[39m=\u001b[39mcandidates)\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m pl_profile \u001b[39m=\u001b[39m pl\u001b[39m.\u001b[39mgenerate_profile(number_of_ballots)\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m \u001b[39m# Bradley-Terry\u001b[39;00m\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m bt \u001b[39m=\u001b[39m bg\u001b[39m.\u001b[39mBradleyTerry(pref_interval_by_bloc\u001b[39m=\u001b[39mpref_interval_by_bloc,\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=9'>10</a>\u001b[0m                      bloc_voter_prop\u001b[39m=\u001b[39mbloc_voter_prop, \n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/cdonnay/PycharmProjects/VoteKit/notebooks/pref_prof_generators.ipynb#X12sZmlsZQ%3D%3D?line=10'>11</a>\u001b[0m                      candidates\u001b[39m=\u001b[39mcandidates)\n",
-      "File \u001b[0;32m~/PycharmProjects/VoteKit/src/votekit/ballot_generator.py:382\u001b[0m, in \u001b[0;36mPlackettLuce.generate_profile\u001b[0;34m(self, number_of_ballots)\u001b[0m\n\u001b[1;32m    377\u001b[0m     cand_support_vec \u001b[39m=\u001b[39m [pref_interval_dict[cand] \u001b[39mfor\u001b[39;00m cand \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates]\n\u001b[1;32m    379\u001b[0m     \u001b[39mfor\u001b[39;00m _ \u001b[39min\u001b[39;00m \u001b[39mrange\u001b[39m(num_ballots):\n\u001b[1;32m    380\u001b[0m         \u001b[39m# generates ranking based on probability distribution of candidate support\u001b[39;00m\n\u001b[1;32m    381\u001b[0m         ballot \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\n\u001b[0;32m--> 382\u001b[0m             np\u001b[39m.\u001b[39mrandom\u001b[39m.\u001b[39mchoice(\n\u001b[1;32m    383\u001b[0m                 \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates,\n\u001b[1;32m    384\u001b[0m                 \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mballot_length,\n\u001b[1;32m    385\u001b[0m                 p\u001b[39m=\u001b[39mcand_support_vec,\n\u001b[1;32m    386\u001b[0m                 replace\u001b[39m=\u001b[39m\u001b[39mFalse\u001b[39;00m,\n\u001b[1;32m    387\u001b[0m             )\n\u001b[1;32m    388\u001b[0m         )\n\u001b[1;32m    390\u001b[0m         ballot_pool\u001b[39m.\u001b[39mappend(ballot)\n\u001b[1;32m    392\u001b[0m pp \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mballot_pool_to_profile(\n\u001b[1;32m    393\u001b[0m     ballot_pool\u001b[39m=\u001b[39mballot_pool, candidates\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcandidates\n\u001b[1;32m    394\u001b[0m )\n",
-      "File \u001b[0;32mnumpy/random/mtrand.pyx:1007\u001b[0m, in \u001b[0;36mnumpy.random.mtrand.RandomState.choice\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: Fewer non-zero entries in p than size"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Ballots  Weight\n",
+      "(A, B, C)      20\n",
+      "(B, A, C)      11\n",
+      "(B, C, A)       5\n",
+      "(A, C, B)       5\n",
+      "(C, B, A)       5\n",
+      "(C, A, B)       4\n"
      ]
     }
    ],
@@ -132,14 +135,6 @@
     "                     candidates=candidates)\n",
     "\n",
     "pl_profile = pl.generate_profile(number_of_ballots)\n",
-    "\n",
-    "# Bradley-Terry\n",
-    "bt = bg.BradleyTerry(pref_interval_by_bloc=pref_interval_by_bloc,\n",
-    "                     bloc_voter_prop=bloc_voter_prop, \n",
-    "                     candidates=candidates)\n",
-    "\n",
-    "bt_profile = bt.generate_profile(number_of_ballots)\n",
-    "\n",
     "print(pl_profile)"
    ]
   },
@@ -147,9 +142,161 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternating Crossover\n",
-    "Cambridge Sampler"
+    "The Bradley-Terry (BT) model also fundamentally relies on these preference intervals. The probability that BT samples the ballot $(A>B>C)$ is the product of the pairwise probabilities $(A>B), (A>C),$ and $(B>C)$. Using our preference intervals, the probability that $A>B$ is $\\frac{A}{A+B}$; out of a line segment of length $A+B$, this is the probability that a uniform random point lies in the $A$ portion. The other probabilities are computed similarly."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Ballots  Weight\n",
+      "(A, B, C)      16\n",
+      "(B, A, C)      15\n",
+      "(A, C, B)      11\n",
+      "(B, C, A)       4\n",
+      "(C, A, B)       2\n",
+      "(C, B, A)       2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Bradley-Terry\n",
+    "bt = bg.BradleyTerry(pref_interval_by_bloc=pref_interval_by_bloc,\n",
+    "                     bloc_voter_prop=bloc_voter_prop, \n",
+    "                     candidates=candidates)\n",
+    "\n",
+    "bt_profile = bt.generate_profile(number_of_ballots)\n",
+    "\n",
+    "print(bt_profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can do a more complicated example of PL and BT. Consider an election where there are 2 blocs of voters, $Q$ and $R$. There are two candidates from the $Q$ bloc, and two from the $R$ bloc. The $R$ block is more insular, and expresses no interest in any of the $Q$ candidates, while the $Q$ bloc does have some preference for $R$'s candidates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = [\"Q1\", \"Q2\", \"R1\", \"R2\"]\n",
+    "number_of_ballots = 51\n",
+    "\n",
+    "bloc_voter_prop = {\"Q\": 0.7, \"R\": 0.3}\n",
+    "\n",
+    "pref_interval_by_bloc = {\n",
+    "    \"Q\": {\"Q1\": 0.4, \"Q2\": 0.3, \"R1\": 0.2, \"R2\": 0.1},\n",
+    "    \"R\": {\"Q1\": 0, \"Q2\": 0, \"R1\": 0.4, \"R2\": 0.6}\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "51\n",
+      "                     Ballots  Weight\n",
+      "(R2, R1, {'Q1', 'Q2'} (Tie))      12\n",
+      "            (Q1, Q2, R1, R2)       8\n",
+      "            (R1, Q1, Q2, R2)       6\n",
+      "            (Q1, R1, R2, Q2)       4\n",
+      "            (Q2, Q1, R1, R2)       3\n",
+      "            (Q2, R1, Q1, R2)       3\n",
+      "(R1, R2, {'Q1', 'Q2'} (Tie))       3\n",
+      "            (Q2, Q1, R2, R1)       2\n",
+      "            (Q1, R2, R1, Q2)       2\n",
+      "            (Q1, Q2, R2, R1)       2\n",
+      "            (R1, R2, Q1, Q2)       1\n",
+      "            (R2, Q2, Q1, R1)       1\n",
+      "            (R2, R1, Q1, Q2)       1\n",
+      "            (Q1, R2, Q2, R1)       1\n",
+      "            (Q2, R2, Q1, R1)       1\n"
+     ]
+    }
+   ],
+   "source": [
+    "pl = bg.PlackettLuce(pref_interval_by_bloc=pref_interval_by_bloc,\n",
+    "                     bloc_voter_prop=bloc_voter_prop, \n",
+    "                     candidates=candidates)\n",
+    "\n",
+    "pl_profile = pl.generate_profile(number_of_ballots)\n",
+    "\n",
+    "print(pl_profile.num_ballots())\n",
+    "print(pl_profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the number of ballots generated may not perfectly match the number we asked for. This is because the PL model tries to generate ballots in proportion with the blocs, and there is some rounding that occurs at this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "51\n",
+      "                     Ballots  Weight\n",
+      "(R1, R2, {'Q1', 'Q2'} (Tie))       8\n",
+      "            (Q1, Q2, R1, R2)       8\n",
+      "(R2, R1, {'Q1', 'Q2'} (Tie))       7\n",
+      "            (Q1, R1, Q2, R2)       4\n",
+      "            (Q1, Q2, R2, R1)       3\n",
+      "            (R1, Q2, Q1, R2)       3\n",
+      "            (Q2, R1, Q1, R2)       3\n",
+      "            (Q2, Q1, R1, R2)       3\n",
+      "            (R2, Q1, Q2, R1)       2\n",
+      "            (Q2, R2, Q1, R1)       2\n",
+      "            (Q2, Q1, R2, R1)       2\n",
+      "            (R2, Q1, R1, Q2)       1\n",
+      "            (Q2, R2, R1, Q1)       1\n",
+      "            (Q1, R1, R2, Q2)       1\n",
+      "            (R1, Q1, Q2, R2)       1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Bradley-Terry\n",
+    "bt = bg.BradleyTerry(pref_interval_by_bloc=pref_interval_by_bloc,\n",
+    "                     bloc_voter_prop=bloc_voter_prop, \n",
+    "                     candidates=candidates)\n",
+    "\n",
+    "bt_profile = bt.generate_profile(number_of_ballots)\n",
+    "print(bt_profile.num_ballots())\n",
+    "print(bt_profile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It remains for us to discuss the Alternating Crossover and Cambridge Sampler methods."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ networkx = "^3.1"
 jinja2 = "^3.1.2"
 matplotlib = "^3.7.2"
 pandas = "^1.5.3"
+apportionment = "^1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -373,7 +373,8 @@ class PlackettLuce(BallotGenerator):
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
         blocs = list(self.bloc_voter_prop.keys())
         bloc_props = list(self.bloc_voter_prop.values())
-        ballots_per_block = dict(zip(blocs, apportion.compute("huntington", bloc_props, number_of_ballots)))
+        ballots_per_block = dict(zip(blocs, apportion.compute("huntington", bloc_props, 
+                                                              number_of_ballots)))
 
         for bloc in self.bloc_voter_prop.keys():
             # number of voters in this bloc
@@ -467,7 +468,8 @@ class BradleyTerry(BallotGenerator):
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
         blocs = list(self.bloc_voter_prop.keys())
         bloc_props = list(self.bloc_voter_prop.values())
-        ballots_per_block = dict(zip(blocs, apportion.compute("huntington", bloc_props, number_of_ballots)))
+        ballots_per_block = dict(zip(blocs, apportion.compute("huntington", bloc_props, 
+                                                              number_of_ballots)))
 
         for bloc in self.bloc_voter_prop.keys():
             pref_interval_dict = self.pref_interval_by_bloc[bloc]

--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -609,8 +609,7 @@ class AlternatingCrossover(BallotGenerator):
                     # check that ballot_length is shorter than total number of cands
                     ballot_pool.append(ballot)
 
-                # Bloc ballots
-                # gonna go wrong with more than 2 blocs, not the right number of non-crossover
+                # Bloc ballot
                 for _ in range(num_ballots - num_crossover_ballots):
                     ballot = bloc_cands + opposing_cands
                     ballot_pool.append(ballot)

--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -373,25 +373,35 @@ class PlackettLuce(BallotGenerator):
             # number of voters in this bloc
             num_ballots = self.round_num(number_of_ballots * self.bloc_voter_prop[bloc])
             pref_interval_dict = self.pref_interval_by_bloc[bloc]
+
+            # finds candidates with non-zero preference
+            non_zero_cands = [cand for cand, pref in pref_interval_dict.items() if pref > 0]
             # creates the interval of probabilities for candidates supported by this block
-            cand_support_vec = [pref_interval_dict[cand] for cand in self.candidates]
+            cand_support_vec = [pref_interval_dict[cand] for cand in non_zero_cands]
+
 
             for _ in range(num_ballots):
-                # generates ranking based on probability distribution of candidate support
-                ballot = list(
+                # generates ranking based on probability distribution of non candidate support
+                non_zero_ranking = list(
                     np.random.choice(
-                        self.candidates,
-                        self.ballot_length,
+                        non_zero_cands,
+                        len(non_zero_cands),
                         p=cand_support_vec,
                         replace=False,
                     )
                 )
 
-                ballot_pool.append(ballot)
+                ranking = [{cand} for cand in non_zero_ranking]
 
-        pp = self.ballot_pool_to_profile(
-            ballot_pool=ballot_pool, candidates=self.candidates
-        )
+                # add zero support candidates to end as tie
+                zero_cands = set(self.candidates).difference(non_zero_cands)
+                if len(zero_cands) > 0:
+                    ranking.append(zero_cands)
+                
+                ballot_pool.append(Ballot(ranking = ranking, weight = Fraction(1,1)))
+
+        pp = PreferenceProfile(ballots = ballot_pool)
+        pp.condense_ballots()
         return pp
 
 
@@ -446,37 +456,57 @@ class BradleyTerry(BallotGenerator):
         return ranking_to_prob
 
     def generate_profile(self, number_of_ballots) -> PreferenceProfile:
-
-        permutations = list(it.permutations(self.candidates, self.ballot_length))
-        ballot_pool: list[list] = []
+        ballot_pool: list[Ballot] = []
 
         for bloc in self.bloc_voter_prop.keys():
-            num_ballots = self.round_num(number_of_ballots * self.bloc_voter_prop[bloc])
             pref_interval_dict = self.pref_interval_by_bloc[bloc]
+            # compute non-zero pref candidates
+            non_zero_pref_dict = {cand: prop for cand, prop in pref_interval_dict.items() if prop>0}
+            non_zero_cands = non_zero_pref_dict.keys()
+            zero_cands = set(self.candidates).difference(non_zero_cands)
 
+            # all possible rankings of non zero candidates
+            permutations = list(it.permutations(non_zero_cands, len(non_zero_cands)))       
+
+            num_ballots = self.round_num(number_of_ballots * self.bloc_voter_prop[bloc])
+            
+            # compute the prob of each ranking given bloc support
             ranking_to_prob = self._calc_prob(
-                permutations=permutations, cand_support_dict=pref_interval_dict
+                permutations=permutations, cand_support_dict=non_zero_pref_dict
             )
 
-            indices = range(len(ranking_to_prob))
-            prob_distrib = list(ranking_to_prob.values())
-            prob_distrib = [float(p) / sum(prob_distrib) for p in prob_distrib]
-
-            ballots_indices = np.random.choice(
-                indices,
-                num_ballots,
-                p=prob_distrib,
-                replace=True,
-            )
-
+            # numpy can only sample from 1D arrays, so we sample the indices instead of rankings
             rankings = list(ranking_to_prob.keys())
-            ballots = [rankings[i] for i in ballots_indices]
+            indices = range(len(rankings))
+            probs = list(ranking_to_prob.values())
 
-            ballot_pool = ballot_pool + ballots
+            # create distribution to sample ballots from
+            normalizing_constant = sum(probs)
+            prob_distrib = [float(p) / normalizing_constant for p in probs]
 
-        pp = self.ballot_pool_to_profile(
-            ballot_pool=ballot_pool, candidates=self.candidates
-        )
+            # sample ballots
+            for _ in range(num_ballots):
+                index = list(np.random.choice(
+                    indices,
+                    1,
+                    p=prob_distrib,
+                ))[0]
+
+                # convert index to ranking
+                ranking = [{cand} for cand in rankings[index]]
+
+                # add any zero candidates as ties
+                if len(zero_cands) > 0 :
+                    ranking.append(zero_cands)
+
+                ballot = Ballot(ranking  = ranking, weight =Fraction(1,1))
+                ballot_pool.append(ballot)
+
+        # pp = self.ballot_pool_to_profile(
+        #     ballot_pool=ballot_pool, candidates=self.candidates
+        # )
+        pp = PreferenceProfile(ballots = ballot_pool)
+        pp.condense_ballots()
         return pp
 
 
@@ -537,7 +567,7 @@ class AlternatingCrossover(BallotGenerator):
                 opposing_cands = self.slate_to_candidates[opposing_slate]
                 bloc_cands = self.slate_to_candidates[bloc]
 
-                for _ in range(num_crossover_ballots):
+                for _ in range(num_crossover_ballots):  
                     pref_for_opposing = [
                         pref_interval_dict[cand] for cand in opposing_cands
                     ]
@@ -580,6 +610,7 @@ class AlternatingCrossover(BallotGenerator):
                     ballot_pool.append(ballot)
 
                 # Bloc ballots
+                # gonna go wrong with more than 2 blocs, not the right number of non-crossover
                 for _ in range(num_ballots - num_crossover_ballots):
                     ballot = bloc_cands + opposing_cands
                     ballot_pool.append(ballot)

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -111,11 +111,20 @@ class PreferenceProfile(BaseModel):
         for ballot in self.ballots:
             part = []
             for ranking in ballot.ranking:
-                for cand in ranking:
-                    if len(ranking) > 2:
-                        part.append(f"{cand} (Tie)")
-                    else:
-                        part.append(cand)
+                if len(ranking) == 1:
+                    part.append(list(ranking)[0])
+                
+                else:
+                    part.append(f"{ranking} (Tie)")
+                # for cand in ranking:
+                #     if len(ranking) == 1:
+                #         part.append(cand)
+
+                #     else:
+                #         print("found tie")
+                #         part.append(f"{cand} (Tie)")
+                #     else:
+                #         part.append(cand)
             ballots.append(tuple(part))
             weights.append(int(ballot.weight))
 

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -116,15 +116,7 @@ class PreferenceProfile(BaseModel):
                 
                 else:
                     part.append(f"{ranking} (Tie)")
-                # for cand in ranking:
-                #     if len(ranking) == 1:
-                #         part.append(cand)
-
-                #     else:
-                #         print("found tie")
-                #         part.append(f"{cand} (Tie)")
-                #     else:
-                #         part.append(cand)
+                    
             ballots.append(tuple(part))
             weights.append(int(ballot.weight))
 


### PR DESCRIPTION
Add a tutorial notebook for the ballot generator models, with the exception of Alternating Crossover and Cambridge Sampler.  In creating the tutorial, I found that the PL and BT models could not handle the case when a candidate had 0 support from a bloc. I added code to handle this case. I also fixed how `PreferenceProfiles` are printed so that you can see ties.