### PR TITLE
STV Updates

### DIFF
--- a/src/votekit/elections/election_types.py
+++ b/src/votekit/elections/election_types.py
@@ -114,9 +114,12 @@ class STV(Election):
                     self.run_step()
 
                 while self.state.curr_round > step:
-                    self.state = self.state.previous
+                    if self.state.previous:
+                        self.state = self.state.previous
+                    else:
+                        raise ValueError("Previous state is None type.") 
 
-                return(self.state)
+            return(self.state)
 
         # run next step   
         else:

--- a/src/votekit/elections/election_types.py
+++ b/src/votekit/elections/election_types.py
@@ -82,10 +82,10 @@ class STV(Election):
 
     def next_round(self) -> bool:
         """
-        Determines if the number of seats has been met to call an election
+        Determines if another round is needed.
 
         Returns:
-            True if number of seats has been met, False otherwise
+            True if number of seats has not been met, False otherwise.
         """
         cands_elected = 0
         for s in self.state.get_all_winners():
@@ -99,6 +99,11 @@ class STV(Election):
         Returns:
            An ElectionState object for a given round
         """
+        if not self.next_round():
+            raise ValueError(
+                f"Length of elected set equal to number of seats ({self.seats})"
+            )
+
         remaining = self.state.profile.get_candidates()
         ballots = self.state.profile.get_ballots()
         round_votes = compute_votes(remaining, ballots)

--- a/src/votekit/elections/transfers.py
+++ b/src/votekit/elections/transfers.py
@@ -24,12 +24,8 @@ def fractional_transfer(
     transfer_value = (votes[winner] - threshold) / votes[winner]
 
     for ballot in ballots:
-        new_ranking = []
         if ballot.ranking and ballot.ranking[0] == {winner}:
             ballot.weight = ballot.weight * transfer_value
-            for cand in ballot.ranking:
-                if cand != {winner}:
-                    new_ranking.append(cand)
 
     return remove_cand(winner, ballots)
 

--- a/src/votekit/models.py
+++ b/src/votekit/models.py
@@ -24,6 +24,13 @@ class Election(ABC):
     def run_step(self, *args: Any, **kwargs: Any):
         pass
 
+    def reset(self):
+        """
+        Reset the ElectionState object to initial conditions.
+        """
+
+        self.state = ElectionState(curr_round=0, profile=self._profile)
+
     @abstractmethod
     def run_election(self, *args: Any, **kwargs: Any):
         pass

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -3,6 +3,7 @@ from fractions import Fraction
 import pandas as pd
 from pydantic import BaseModel, validator
 from typing import Optional
+import copy
 
 from .ballot import Ballot
 
@@ -37,7 +38,7 @@ class PreferenceProfile(BaseModel):
         """
         Returns list of ballots
         """
-        return self.ballots
+        return copy.deepcopy(self.ballots)
 
     def get_candidates(self) -> list:
         """


### PR DESCRIPTION
When running an STV election, I noticed that you cannot use the `run_election` method more than once. Moreover, I noticed that after `run_election`, the original preference profile was edited, not just the one stored in `self.state.profile`. 

1. I implemented a `reset` method in the `Election` class that resets `self.state` to round 0 and the original preference profile.
2. The `get_ballots` method was returning the `PreferenceProfile` list of ballots, which was why running elections altered the original profile. I used `deepcopy` to return a copy of the ballots, which fixed the issue.
3. I implemented a `step` parameter in the STV `run_step` method that allows users to choose which step they want to run. It defaults to `None`, in which case it just runs the next step.
4. I added a `ValueError` to `run_step` so that if you try to run a step after all seats are filled, it raise the error.

@jamesturk @drdeford @jgibson517 @jennjwang @ziglaser