### PR TITLE
Some post tutorial updates

### DIFF
--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -464,7 +464,7 @@ class PlackettLuce(BallotGenerator):
                 ballot_pool.append(Ballot(ranking=ranking, weight=Fraction(1, 1)))
 
         pp = PreferenceProfile(ballots=ballot_pool)
-        pp.condense_ballots()
+        pp = pp.condense_ballots()
         return pp
 
 
@@ -585,7 +585,7 @@ class BradleyTerry(BallotGenerator):
         #     ballot_pool=ballot_pool, candidates=self.candidates
         # )
         pp = PreferenceProfile(ballots=ballot_pool)
-        pp.condense_ballots()
+        pp = pp.condense_ballots()
         return pp
 
 
@@ -715,7 +715,7 @@ class AlternatingCrossover(BallotGenerator):
                 ballot_pool.append(ballot)
 
         pp = PreferenceProfile(ballots=ballot_pool, candidates=self.candidates)
-        pp.condense_ballots()
+        pp = pp.condense_ballots()
         return pp
 
 

--- a/src/votekit/election_state.py
+++ b/src/votekit/election_state.py
@@ -91,9 +91,9 @@ class ElectionState(BaseModel):
         """
         if self.curr_round == round:
             return {
-                "Elected": [s for s in self.elected ],
-                "Eliminated": [s for s in self.eliminated_cands],
-                "Remaining": [s for s in self.remaining]
+                "Elected": self.elected,
+                "Eliminated": self.eliminated_cands,
+                "Remaining": self.remaining
             }
         elif self.previous:
             return self.previous.round_outcome(round)

--- a/src/votekit/elections/__init__.py
+++ b/src/votekit/elections/__init__.py
@@ -10,6 +10,7 @@ from .election_types import (  # noqa
     DominatingSets,
     CondoBorda,
     Plurality,
+    IRV
 )
 
 from .transfers import seqRCV_transfer, fractional_transfer, random_transfer  # noqa

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -308,6 +308,14 @@ class BallotGraph(Graph):
         else:
             node_labels = self.label_weights(to_display)
             
+            # if not labeling the nodes with candidates and graph is drawn from profile,
+            # print labeling dictionary
+            if self.profile and self.candidates:
+                print("The candidates are labeled as follows.")
+                cand_dict = self._number_cands(cands = tuple(self.candidates))
+                for cand,value in cand_dict.items():
+                    print(value,cand)
+            
         subgraph = self.graph.subgraph(ballots)
 
         pos = nx.spring_layout(subgraph)

--- a/src/votekit/graphs/pairwise_comparison_graph.py
+++ b/src/votekit/graphs/pairwise_comparison_graph.py
@@ -255,9 +255,9 @@ class PairwiseComparisonGraph(Graph):
             greater than 2.
 
         Returns:
-            List of condorcet cycles
+            List of condorcet cycles sorted by length.
         """
 
         G = self.pairwise_graph
-
-        return(nx.recursive_simple_cycles(G))
+        list_of_cycles = nx.recursive_simple_cycles(G)
+        return(sorted(list_of_cycles, key=lambda x: len(x)))

--- a/src/votekit/graphs/pairwise_comparison_graph.py
+++ b/src/votekit/graphs/pairwise_comparison_graph.py
@@ -2,6 +2,7 @@ from fractions import Fraction
 from itertools import permutations, combinations
 import matplotlib.pyplot as plt  # type: ignore
 import networkx as nx  # type: ignore
+from functools import cache
 
 from ..ballot import Ballot
 from .base_graph import Graph
@@ -179,7 +180,7 @@ class PairwiseComparisonGraph(Graph):
         plt.close()
 
     # More complicated Requests
-    def has_condorcet(self) -> bool:
+    def has_condorcet_winner(self) -> bool:
         """
         Checks if graph has a condorcet winner.
 
@@ -190,7 +191,22 @@ class PairwiseComparisonGraph(Graph):
         if len(dominating_tiers[0]) == 1:
             return True
         return False
+    
+    def get_condorcet_winner(self) -> str:
+        """
+        Returns the condorcet winner. Raises a ValueError if no condorcet winner.
 
+        Returns:
+            The condorcet winner.
+        """
+        
+        if self.has_condorcet_winner():
+            return list(self.dominating_tiers()[0])[0]
+
+        else:
+            raise ValueError("There is no condorcet winner.")
+
+    @cache
     def dominating_tiers(self) -> list[set]:
         """
         Finds dominating tiers within an election.
@@ -216,3 +232,32 @@ class PairwiseComparisonGraph(Graph):
                 tier_dict[v] = {k}
         tier_list = [tier_dict[k] for k in sorted(tier_dict.keys(), reverse=True)]
         return tier_list
+
+    def has_condorcet_cycles(self) -> bool:
+        """
+        Checks if graph has any condorcet cycles, which we define as any cycle of length
+            greater than 2 in the graph.
+
+        Returns:
+            True if condorcet cycles exists, False otherwise.
+        """
+
+        if len(self.get_condorcet_cycles()) > 0:
+            return True
+
+        else:
+            return False
+
+    @cache
+    def get_condorcet_cycles(self) -> list:
+        """
+        Returns a list of condorcet cycles in the graph, which we define as any cycle of length
+            greater than 2.
+
+        Returns:
+            List of condorcet cycles
+        """
+
+        G = self.pairwise_graph
+
+        return(nx.recursive_simple_cycles(G))

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -284,6 +284,9 @@ class PreferenceProfile(BaseModel):
         for b in pp_1.ballots:
             if b not in pp_2.ballots:
                 return False
+        for b in pp_2.ballots:
+            if b not in pp_1.ballots:
+                return False
         return True
 
     def _sum_row(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
 import csv
 from fractions import Fraction
 import pandas as pd
 from pydantic import BaseModel, validator
 from typing import Optional
 import numpy as np
-
 from .ballot import Ballot
 
 
@@ -211,13 +211,14 @@ class PreferenceProfile(BaseModel):
             self.df = self._create_df()
 
         if sort_by_weight:
-            if n > len(self.df):
-                n = len(self.df)
-            df = self.df.sort_values(by="Weight", ascending=True).reindex(
-                range(len(self.df) - 1, len(self.df) - n - 1, -1)
-            )
+            df = self.df.sort_values(by="Weight", ascending=True)
+            df["New Index"] = [x for x in range(len(self.df) - 1, -1, -1)]
+            df = df.set_index("New Index").head(n)
+            df.index.name = None
+            
         else:
-            df = self.df.tail(n)
+            df = self.df.iloc[::-1].head(n)
+
 
         if totals:
             df = self._sum_row(df)
@@ -248,9 +249,12 @@ class PreferenceProfile(BaseModel):
     # set repr to print outputs
     __repr__ = __str__
 
-    def condense_ballots(self):
+    def condense_ballots(self) -> PreferenceProfile:
         """
         Groups ballots by rankings and updates weights.
+
+        Returns:
+            A PreferenceProfile object with condensed ballot list.
         """
         class_vector = []
         seen_rankings = []
@@ -261,28 +265,24 @@ class PreferenceProfile(BaseModel):
 
         new_ballot_list = []
         for i, ranking in enumerate(seen_rankings):
-            total_weight = 0
+            total_weight = Fraction(0)
             for j in range(len(class_vector)):
                 if class_vector[j] == i:
                     total_weight += self.ballots[j].weight
             new_ballot_list.append(
                 Ballot(ranking=ranking, weight=Fraction(total_weight))
             )
-        self.ballots = new_ballot_list
 
-        # create new dataframe with condensed ballots
-        self.df = self._create_df()
+        condensed_profile = PreferenceProfile(ballots = new_ballot_list)
+        return condensed_profile
 
     def __eq__(self, other):
         if not isinstance(other, PreferenceProfile):
             return False
-        self.condense_ballots()
-        other.condense_ballots()
-        for b in self.ballots:
-            if b not in other.ballots:
-                return False
-        for b in self.ballots:
-            if b not in other.ballots:
+        pp_1 = self.condense_ballots()
+        pp_2 = other.condense_ballots()
+        for b in pp_1.ballots:
+            if b not in pp_2.ballots:
                 return False
         return True
 

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -42,7 +42,9 @@ def compute_votes(
         ballots: List of Ballot objects.
 
     Returns:
-        List of tuples (candidate, number of votes) ordered by first place votes.
+        A tuple (ordered, votes) where ordered is a list of tuples (cand, first place votes) 
+            ordered by decreasing first place votes and votes is a dictionary whose keys are 
+            candidates and values are first place votes.
     """
     votes = {cand: Fraction(0) for cand in candidates}
 
@@ -117,12 +119,16 @@ def remove_cand(removed: Union[str, Iterable], ballots: list[Ballot]) -> list[Ba
 
 
 # Summmary Stat functions
-def first_place_votes(profile: PreferenceProfile) -> dict:
+def first_place_votes(profile: PreferenceProfile,
+                      to_float: bool = False) -> dict:
     """
     Calculates first-place votes for a PreferenceProfile.
 
     Args:
         profile: Inputed PreferenceProfile of ballots.
+
+        to_float: If True, compute first place votes as floats instead of Fractions. Defaults to
+                    False.
 
     Returns:
         Dictionary of candidates (keys) and first place vote totals (values).
@@ -132,7 +138,11 @@ def first_place_votes(profile: PreferenceProfile) -> dict:
 
     _, votes_dict = compute_votes(cands, ballots)
 
-    return votes_dict
+    if to_float:
+        votes_dict = {k:float(v) for k,v in votes_dict.items()}
+        return votes_dict
+    else:
+        return votes_dict
 
 
 def mentions(profile: PreferenceProfile) -> dict:

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -29,6 +29,27 @@ COLOR_LIST = [
 # Election Helper Functions
 CandidateVotes = namedtuple("CandidateVotes", ["cand", "votes"])
 
+def ballots_by_first_cand(candidates:list[str], ballots: list[Ballot]) -> dict:
+    """
+    Partitions the ballots by first place candidate. 
+
+    Returns:
+        A dictionary whose keys are candidates and values are lists of ballots.
+    """
+    cand_dict = {c:[] for c in candidates} # type: dict
+
+    for b in ballots:
+        if b.ranking:
+            # find first place candidate, ensure there is only one
+            first_cand = list(b.ranking[0])
+            if len(first_cand)>1:
+                raise ValueError(f"Ballot {b} has a tie for first.")
+            else:
+                first_cand = first_cand[0]
+
+            cand_dict[first_cand].append(b)
+        
+    return cand_dict
 
 def compute_votes(
     candidates: list,

--- a/tests/test_election_state.py
+++ b/tests/test_election_state.py
@@ -125,7 +125,7 @@ def test_round_previous():
     )
 
     results = second.round_outcome(round=1)
-    assert results == {"Elected": ["A", "B"], "Eliminated": ["C"]}
+    assert results == {"Elected": [{"A"}, {"B"}], "Eliminated": [{"C"}], "Remaining": []}
 
 
 def test_round_outcome_error():

--- a/tests/test_pref_profile.py
+++ b/tests/test_pref_profile.py
@@ -47,8 +47,8 @@ def test_condense_profile():
             Ballot(ranking=[{"A"}, {"B"}, {"C"}], weight=Fraction(2)),
         ]
     )
-    profile.condense_ballots()
-    assert profile.ballots[0] == Ballot(
+    pp = profile.condense_ballots()
+    assert pp.ballots[0] == Ballot(
         ranking=[{"A"}, {"B"}, {"C"}], weight=Fraction(3)
     )
 

--- a/tests/test_pwc_graph.py
+++ b/tests/test_pwc_graph.py
@@ -68,9 +68,9 @@ def test_pwcg_dominating_tiers():
     assert dominating_tiers == target_dominating_tiers
 
 
-def test_pwcg_has_condorcet():
+def test_pwcg_has_condorcet_winner():
     pwcg = PairwiseComparisonGraph(TEST_PROFILE)
-    pwcg_has_condorcet = pwcg.has_condorcet()
+    pwcg_has_condorcet = pwcg.has_condorcet_winner()
 
     target_has_condorcet = True
 


### PR DESCRIPTION
1. Change the way the `condense_ballots()` method works in profiles. Rather than altering the original profile, it returns a new profile. This gives users the option to preserve the original profile.
2. Add an IRV election class, which is just a wrapper for STV with 1 seat.
3. Add default option to Borda election class, so users do not have to input a score vector if they want to use the traditional Borda vector.
4. Alter STV class so that the remaining candidates are always listed in order of current first place votes.
5. Add print statement to `BallotGraph` so that when you draw the graph without labels, it prints a dictionary of candidate labels for you.
6. Add several methods to `PairwiseComparisonGraph`. Added two boolean methods that return True if there is a condorcet winner or if there is a condorcet cycle. Added two get methods that return the winner or the cycles. Cached the results of `dominating_tiers` and `get_condorcet_cycles`.
7. Fixed an error in the `PreferenceProfile` tail method.
8. Added optional `to_float` method to `first_place_votes` if users want to see them as floats instead of Fractions.

@jamesturk @drdeford @jgibson517 @jennjwang @ziglaser

I will add these to the change log only once the PR has been merged.