### PR TITLE
add SlatePreference model

### DIFF
--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -49,7 +49,7 @@ class Ballot:
         # Check ranking
         if self.ranking != other.ranking:
             return False
-        
+
         # Check weight
         if self.weight != other.weight:
             return False

--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -52,14 +52,12 @@ class BallotGenerator:
         pref_interval_by_bloc=None,
         bloc_voter_prop=None,
         slate_to_candidates: Optional[dict] = None,
-        cohesion_parameters: Optional[dict] = None
+        cohesion_parameters: Optional[dict] = None,
     ):
         self.ballot_length = (
             ballot_length if ballot_length is not None else len(candidates)
         )
         self.candidates = candidates
-
-        
 
         if bloc_voter_prop and pref_interval_by_bloc:  # PL, BT, AC, CS
             if round(sum(bloc_voter_prop.values())) != 1:
@@ -154,32 +152,35 @@ class BallotGenerator:
             data["bloc_voter_prop"] = bloc_voter_prop
 
         if cls == AlternatingCrossover:
-            generator = cls(slate_to_candidates = slate_to_candidates, 
-                            cohesion_parameters = cohesion,
-                            **data)
+            generator = cls(
+                slate_to_candidates=slate_to_candidates,
+                cohesion_parameters=cohesion,
+                **data,
+            )
         elif cls == CambridgeSampler:
-            generator = cls(slate_to_candidates = slate_to_candidates, 
-                            cohesion_parameters = cohesion,
-                            **data)
+            generator = cls(
+                slate_to_candidates=slate_to_candidates,
+                cohesion_parameters=cohesion,
+                **data,
+            )
             if isinstance(generator, CambridgeSampler):
                 generator._rename_blocs()
-        
+
         else:
             generator = cls(**data)
 
         return generator
 
     @abstractmethod
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, Tuple, dict]:
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple, dict]:
         """
         Generates a `PreferenceProfile`.
 
         Args:
             number_of_ballots (int): Number of ballots to generate.
-            by_bloc (bool): True if you want a tuple (pp_by_bloc, pp), which is a dictionary of 
+            by_bloc (bool): True if you want a tuple (pp_by_bloc, pp), which is a dictionary of
                             PreferenceProfiles with keys = blocs and the aggregated profile.
                     False if you want the aggregated profile. Defaults to False.
 
@@ -301,10 +302,9 @@ class BallotSimplex(BallotGenerator):
 
         return cls(alpha=alpha, **data)
 
-    def generate_profile(self, 
-                         number_of_ballots, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, dict]:
+    def generate_profile(
+        self, number_of_ballots, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, dict]:
         """
         Generates a PreferenceProfile from the ballot simplex.
         """
@@ -410,7 +410,6 @@ class ImpartialAnonymousCulture(BallotSimplex):
         super().__init__(alpha=1, **data)
 
 
-
 class BradleyTerry(BallotGenerator):
     """
     Class for generating ballots using a Bradley-Terry model. The probability of sampling
@@ -466,23 +465,23 @@ class BradleyTerry(BallotGenerator):
             ranking_to_prob[ranking] = prob
         return ranking_to_prob
 
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, Tuple]:
-        
-
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
-        
+
         bloc_props = list(self.bloc_voter_prop.values())
         ballots_per_block = dict(
-            zip(self.blocs, apportion.compute("huntington", bloc_props, number_of_ballots))
+            zip(
+                self.blocs,
+                apportion.compute("huntington", bloc_props, number_of_ballots),
+            )
         )
 
         pp_by_bloc = {b: PreferenceProfile() for b in self.blocs}
 
         for bloc in self.blocs:
-            ballot_pool =[]
+            ballot_pool = []
             num_ballots = ballots_per_block[bloc]
 
             pref_interval_dict = self.pref_interval_by_bloc[bloc]
@@ -537,15 +536,14 @@ class BradleyTerry(BallotGenerator):
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pp_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pp_by_bloc, pp)
+            return (pp_by_bloc, pp)
 
         # else return the combined profiles
         else:
             return pp
-
 
 
 class AlternatingCrossover(BallotGenerator):
@@ -600,12 +598,9 @@ class AlternatingCrossover(BallotGenerator):
                     "In AC model, all candidates must have non-zero preference."
                 )
 
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, Tuple]:
-        
-
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         # compute the number of bloc and crossover voters in each bloc using Huntington Hill
         voter_types = [
             (b, type) for b in self.bloc_voter_prop.keys() for type in ["bloc", "cross"]
@@ -624,7 +619,7 @@ class AlternatingCrossover(BallotGenerator):
                 apportion.compute("huntington", voter_props, number_of_ballots),
             )
         )
-        
+
         pp_by_bloc = {b: PreferenceProfile() for b in self.blocs}
 
         for bloc in self.blocs:
@@ -637,7 +632,7 @@ class AlternatingCrossover(BallotGenerator):
             opposing_slate = list(set(self.bloc_voter_prop.keys()).difference([bloc]))[
                 0
             ]
-            
+
             opposing_cands = self.slate_to_candidates[opposing_slate]
             bloc_cands = self.slate_to_candidates[bloc]
 
@@ -687,10 +682,10 @@ class AlternatingCrossover(BallotGenerator):
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pp_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pp_by_bloc, pp)
+            return (pp_by_bloc, pp)
 
         # else return the combined profiles
         else:
@@ -714,10 +709,9 @@ class OneDimSpatial(BallotGenerator):
     See `BallotGenerator` base class.
     """
 
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False 
-                         )-> Union[PreferenceProfile, Tuple]:
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         candidate_position_dict = {c: np.random.normal(0, 1) for c in self.candidates}
         voter_positions = np.random.normal(0, 1, number_of_ballots)
 
@@ -840,14 +834,11 @@ class CambridgeSampler(BallotGenerator):
             for b in self.cohesion_parameters.keys()
         }
 
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                        ) -> Union[PreferenceProfile, Tuple]:
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         with open(self.path, "rb") as pickle_file:
             ballot_frequencies = pickle.load(pickle_file)
-
-        
 
         # compute the number of bloc and crossover voters in each bloc using Huntington Hill
         voter_types = [
@@ -867,13 +858,13 @@ class CambridgeSampler(BallotGenerator):
                 apportion.compute("huntington", voter_props, number_of_ballots),
             )
         )
-        
+
         pp_by_bloc = {b: PreferenceProfile() for b in self.blocs}
 
-        for i,bloc in enumerate(self.blocs):
+        for i, bloc in enumerate(self.blocs):
             ballot_pool = []
             # store the opposition bloc
-            opp_bloc = self.blocs[(i+1)%2]
+            opp_bloc = self.blocs[(i + 1) % 2]
 
             # find total number of ballots that start with bloc and opp_bloc
             bloc_first_count = sum(
@@ -958,7 +949,7 @@ class CambridgeSampler(BallotGenerator):
 
                 ranking = [{cand} for cand in full_ballot]
                 ballot_pool.append(Ballot(ranking=ranking, weight=Fraction(1, 1)))
-            
+
             pp = PreferenceProfile(ballots=ballot_pool)
             pp.condense_ballots()
             pp_by_bloc[bloc] = pp
@@ -966,10 +957,10 @@ class CambridgeSampler(BallotGenerator):
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pp_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pp_by_bloc, pp)
+            return (pp_by_bloc, pp)
 
         # else return the combined profiles
         else:
@@ -979,8 +970,8 @@ class CambridgeSampler(BallotGenerator):
 class Cumulative(BallotGenerator):
     """
     Class for generating cumulative ballots. This model samples with
-    replacement from a preference interval and counts candidates with multiplicity. 
-    Can be initialized with an interval or can be constructed with the Dirichlet distribution 
+    replacement from a preference interval and counts candidates with multiplicity.
+    Can be initialized with an interval or can be constructed with the Dirichlet distribution
     using the `from_params` method in the `BallotGenerator` class.
 
     **Attributes**
@@ -1008,11 +999,9 @@ class Cumulative(BallotGenerator):
         super().__init__(**data)
         self.num_votes = num_votes
 
-
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         )  -> Union[PreferenceProfile, Tuple]:
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         """
         Args:
         `number_of_ballots`: The number of ballots to generate.
@@ -1023,9 +1012,12 @@ class Cumulative(BallotGenerator):
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
         bloc_props = list(self.bloc_voter_prop.values())
         ballots_per_block = dict(
-            zip(self.blocs, apportion.compute("huntington", bloc_props, number_of_ballots))
+            zip(
+                self.blocs,
+                apportion.compute("huntington", bloc_props, number_of_ballots),
+            )
         )
-        
+
         pp_by_bloc = {b: PreferenceProfile() for b in self.blocs}
 
         for bloc in self.bloc_voter_prop.keys():
@@ -1054,7 +1046,6 @@ class Cumulative(BallotGenerator):
 
                 ranking = [{cand} for cand in ranking]
 
-
                 ballot_pool.append(Ballot(ranking=ranking, weight=Fraction(1, 1)))
 
             pp = PreferenceProfile(ballots=ballot_pool)
@@ -1064,20 +1055,21 @@ class Cumulative(BallotGenerator):
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pp_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pp_by_bloc, pp)
+            return (pp_by_bloc, pp)
 
         # else return the combined profiles
         else:
             return pp
-        
+
+
 class shortPlackettLuce(BallotGenerator):
     """
     Class for generating short Plackett Luce ballots. This model samples without
     replacement from a preference interval. Equivalent to Plackett Luce if k = number of candidates.
-    Can be initialized with an interval or can be constructed with the Dirichlet distribution 
+    Can be initialized with an interval or can be constructed with the Dirichlet distribution
     using the `from_params` method in the `BallotGenerator` class.
 
     **Attributes**
@@ -1105,10 +1097,9 @@ class shortPlackettLuce(BallotGenerator):
         super().__init__(**data)
         self.k = k
 
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, Tuple]:
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         """
         Args:
         `number_of_ballots`: The number of ballots to generate.
@@ -1119,7 +1110,10 @@ class shortPlackettLuce(BallotGenerator):
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
         bloc_props = list(self.bloc_voter_prop.values())
         ballots_per_block = dict(
-            zip(self.blocs, apportion.compute("huntington", bloc_props, number_of_ballots))
+            zip(
+                self.blocs,
+                apportion.compute("huntington", bloc_props, number_of_ballots),
+            )
         )
 
         # dictionary to store preference profiles by bloc
@@ -1138,15 +1132,14 @@ class shortPlackettLuce(BallotGenerator):
             # creates the interval of probabilities for candidates supported by this block
             cand_support_vec = [pref_interval_dict[cand] for cand in non_zero_cands]
 
-            # if there aren't enough non-zero supported candidates, 
+            # if there aren't enough non-zero supported candidates,
             # include 0 support as ties
             number_to_sample = self.k
             number_tied = None
 
             if len(non_zero_cands) < number_to_sample:
-                number_tied = number_to_sample-len(non_zero_cands)
+                number_tied = number_to_sample - len(non_zero_cands)
                 number_to_sample = len(non_zero_cands)
-                
 
             for _ in range(num_ballots):
                 # generates ranking based on probability distribution of non candidate support
@@ -1172,28 +1165,28 @@ class shortPlackettLuce(BallotGenerator):
                             number_tied,
                             replace=False,
                         )
-                        )
+                    )
                     ranking.append(set(tied_candidates))
 
                 ballot_pool.append(Ballot(ranking=ranking, weight=Fraction(1, 1)))
-            
+
             # create PP for this bloc
             pp = PreferenceProfile(ballots=ballot_pool)
             pp.condense_ballots()
             pp_by_bloc[bloc] = pp
-        
+
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pp_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pp_by_bloc, pp)
+            return (pp_by_bloc, pp)
 
         # else return the combined profiles
         else:
             return pp
-        
+
 
 class PlackettLuce(shortPlackettLuce):
     """
@@ -1224,16 +1217,16 @@ class PlackettLuce(shortPlackettLuce):
         k = len(data["candidates"])
         # Call the parent class's __init__ method to handle common parameters
         super().__init__(k=k, **data)
-        
+
 
 class SlatePreference(BallotGenerator):
     """
-    Class for generating ballots using a slate preference model. 
+    Class for generating ballots using a slate preference model.
     This model first samples a ballot type by flipping a cohesion parameter weighted coin.
     It then fills out the ballot type via sampling with out replacement from the interval.
 
     Only works with 2 blocs at the moment.
-    
+
     Can be initialized with an interval or can be
     constructed with the Dirichlet distribution using the `from_params` method in the
     `BallotGenerator` class.
@@ -1258,56 +1251,66 @@ class SlatePreference(BallotGenerator):
     See `BallotGenerator` base class
     """
 
-    def __init__(self, 
-                 slate_to_candidates: dict, 
-                 cohesion_parameters: dict, 
-                 **data):
+    def __init__(self, slate_to_candidates: dict, cohesion_parameters: dict, **data):
         # Call the parent class's __init__ method to handle common parameters
         super().__init__(**data)
         self.slate_to_candidates = slate_to_candidates
         self.cohesion_parameters = cohesion_parameters
 
-        if len(self.slate_to_candidates.keys())>2:
-            raise UserWarning(f"This model currently only supports at most two blocs, but you \
-                              passed {len(self.slate_to_candidates.keys())}")
-    
-    def generate_profile(self, 
-                         number_of_ballots: int, 
-                         by_bloc: bool = False
-                         ) -> Union[PreferenceProfile, Tuple]:
+        if len(self.slate_to_candidates.keys()) > 2:
+            raise UserWarning(
+                f"This model currently only supports at most two blocs, but you \
+                              passed {len(self.slate_to_candidates.keys())}"
+            )
+
+    def generate_profile(
+        self, number_of_ballots: int, by_bloc: bool = False
+    ) -> Union[PreferenceProfile, Tuple]:
         # the number of ballots per bloc is determined by Huntington-Hill apportionment
 
-        if len(self.blocs)>2:
-            raise UserWarning(f"This model currently only supports at most two blocs, but you \
-                              passed {len(self.slate_to_candidates.keys())}")
-        
+        if len(self.blocs) > 2:
+            raise UserWarning(
+                f"This model currently only supports at most two blocs, but you \
+                              passed {len(self.slate_to_candidates.keys())}"
+            )
+
         bloc_props = list(self.bloc_voter_prop.values())
         ballots_per_block = dict(
-            zip(self.blocs, apportion.compute("huntington", bloc_props, number_of_ballots))
+            zip(
+                self.blocs,
+                apportion.compute("huntington", bloc_props, number_of_ballots),
+            )
         )
 
         pref_profile_by_bloc = {}
 
-        for i, bloc in enumerate(self.blocs): 
+        for i, bloc in enumerate(self.blocs):
             ballot_pool = []
             # number of voters in this bloc
             num_ballots = ballots_per_block[bloc]
 
             # TODO the code below assumes only two blocs
-            ballot_type_distribution = [self.cohesion_parameters[bloc], 
-                                        1-self.cohesion_parameters[bloc]]
-            non_zero_cands = [c for c,v in self.pref_interval_by_bloc[bloc].items() if v>0]
+            ballot_type_distribution = [
+                self.cohesion_parameters[bloc],
+                1 - self.cohesion_parameters[bloc],
+            ]
+            non_zero_cands = [
+                c for c, v in self.pref_interval_by_bloc[bloc].items() if v > 0
+            ]
 
-            opp_bloc = self.blocs[(i+1)%2]
-            
+            opp_bloc = self.blocs[(i + 1) % 2]
+
             for _ in range(num_ballots):
                 # sample ballot type
                 ballot_type = []
-                candidate_count = {b:0 for b in self.blocs}
+                candidate_count = {b: 0 for b in self.blocs}
                 for _ in range(len(non_zero_cands)):
                     # choose a bloc as the next slot in the ballot
-                    cand_bloc = list(np.random.choice([bloc, opp_bloc], size =1, 
-                                                      p = ballot_type_distribution))[0]
+                    cand_bloc = list(
+                        np.random.choice(
+                            [bloc, opp_bloc], size=1, p=ballot_type_distribution
+                        )
+                    )[0]
                     ballot_type.append(cand_bloc)
                     candidate_count[cand_bloc] += 1
 
@@ -1315,28 +1318,36 @@ class SlatePreference(BallotGenerator):
                     if len(ballot_type) < len(non_zero_cands):
                         for i, b in enumerate(self.blocs):
                             # and you are out of non-zero candidates for a slate
-                            if candidate_count[b] == len([c for c in self.slate_to_candidates[b] 
-                                                        if self.pref_interval_by_bloc[bloc][c]>0]):
-                                 # TODO this assumes only two blocs
-                                 o_bloc = self.blocs[(i+1)%2]
+                            if candidate_count[b] == len(
+                                [
+                                    c
+                                    for c in self.slate_to_candidates[b]
+                                    if self.pref_interval_by_bloc[bloc][c] > 0
+                                ]
+                            ):
+                                # TODO this assumes only two blocs
+                                o_bloc = self.blocs[(i + 1) % 2]
 
-                                 # fill out rest of ballot with opposing bloc
-                                 for i in range(len(non_zero_cands) - len(ballot_type)):
-                                     ballot_type.append(o_bloc)
-                    
+                                # fill out rest of ballot with opposing bloc
+                                for i in range(len(non_zero_cands) - len(ballot_type)):
+                                    ballot_type.append(o_bloc)
+
                     if len(ballot_type) == len(non_zero_cands):
                         break
-            
-                cand_ordering_by_bloc = {   }
+
+                cand_ordering_by_bloc = {}
                 pref_interval = self.pref_interval_by_bloc[bloc]
 
                 for b in self.blocs:
                     # create a pref interval dict of only this blocs candidates
-                    bloc_cand_pref_interval = {c:s for c,s in pref_interval.items() 
-                                               if c in self.slate_to_candidates[b] and s>0}
+                    bloc_cand_pref_interval = {
+                        c: s
+                        for c, s in pref_interval.items()
+                        if c in self.slate_to_candidates[b] and s > 0
+                    }
 
                     cands = list(bloc_cand_pref_interval.keys())
-                    
+
                     # if there are no non-zero candidates, skip this bloc
                     if len(cands) == 0:
                         continue
@@ -1344,24 +1355,24 @@ class SlatePreference(BallotGenerator):
                     distribution = [bloc_cand_pref_interval[c] for c in cands]
                     # normalize
                     mass = sum(distribution)
-                    distribution = [v/mass for v in distribution]
+                    distribution = [v / mass for v in distribution]
 
                     # sample
-                    cand_ordering = np.random.choice(cands, len(cands), 
-                                                     replace=False, p = distribution)
+                    cand_ordering = np.random.choice(
+                        cands, len(cands), replace=False, p=distribution
+                    )
                     cand_ordering_by_bloc[b] = list(cand_ordering)
-                
+
                 ranking = []
                 for b in ballot_type:
                     # append the current first candidate, then remove them from the ordering
                     ranking.append({cand_ordering_by_bloc[b].pop(0)})
-                
-                zero_cands = {c for c,s in pref_interval.items() if s == 0}
+
+                zero_cands = {c for c, s in pref_interval.items() if s == 0}
                 if len(zero_cands) > 0:
                     ranking.append(zero_cands)
-                ballot_pool.append(Ballot(ranking =ranking, weight = Fraction(1,1)))
+                ballot_pool.append(Ballot(ranking=ranking, weight=Fraction(1, 1)))
 
-           
             pp = PreferenceProfile(ballots=ballot_pool)
             pp = pp.condense_ballots()
             pref_profile_by_bloc[bloc] = pp
@@ -1369,10 +1380,10 @@ class SlatePreference(BallotGenerator):
         # combine the profiles
         pp = PreferenceProfile(ballots=[])
         for profile in pref_profile_by_bloc.values():
-            pp+= profile
+            pp += profile
 
         if by_bloc:
-            return(pref_profile_by_bloc, pp)
+            return (pref_profile_by_bloc, pp)
 
         # else return the combined profiles
         else:

--- a/src/votekit/cleaning.py
+++ b/src/votekit/cleaning.py
@@ -17,7 +17,7 @@ def remove_empty_ballots(
     Args:
         pp (PreferenceProfile): A PreferenceProfile to clean.
         keep_candidates (bool, optional): If True, keep all of the candidates
-            from the original PreferenceProfile in the returned PreferenceProfile, even if 
+            from the original PreferenceProfile in the returned PreferenceProfile, even if
             they got no votes. Defaults to False.
 
     Returns:
@@ -44,7 +44,7 @@ def clean_profile(
 
     Args:
         pp (PreferenceProfile): A PreferenceProfile to clean.
-        clean_ballot_func (Callable[[Ballot], Ballot]): Function that 
+        clean_ballot_func (Callable[[Ballot], Ballot]): Function that
             takes a list of ballots and cleans each ballot.
 
     Returns:

--- a/src/votekit/cvr_loaders.py
+++ b/src/votekit/cvr_loaders.py
@@ -60,7 +60,7 @@ def load_csv(
 
     if rank_cols:
         if id_col is not None:
-            df = df.iloc[:, rank_cols+[id_col]]
+            df = df.iloc[:, rank_cols + [id_col]]
         else:
             df = df.iloc[:, rank_cols]
 
@@ -72,7 +72,6 @@ def load_csv(
 
     for group, group_df in grouped:
         ranking = [{None} if pd.isnull(c) else {c} for c in group]
-
 
         voter_set = None
         if id_col is not None:
@@ -99,7 +98,7 @@ def load_scottish(fpath: str) -> tuple[PreferenceProfile, int]:
         DataError: If there is missing or incorrect metadata or candidate data.
 
     Returns:
-        (tuple): A tuple (PreferenceProfile, seats) representing the election and the 
+        (tuple): A tuple (PreferenceProfile, seats) representing the election and the
                 number of seats in the election.
     """
     ballots = []

--- a/src/votekit/election_state.py
+++ b/src/votekit/election_state.py
@@ -93,7 +93,7 @@ class ElectionState(BaseModel):
             return {
                 "Elected": self.elected,
                 "Eliminated": self.eliminated_cands,
-                "Remaining": self.remaining
+                "Remaining": self.remaining,
             }
         elif self.previous:
             return self.previous.round_outcome(round)
@@ -159,8 +159,10 @@ class ElectionState(BaseModel):
                         if len(s) > 1:
                             remaining_cands = ", ".join(list(s.difference(cand)))
                             tied_str = f" (tie with {remaining_cands})"
-                        
-                        status_df.loc[status_df["Candidate"] == cand, "Status"] = status + tied_str
+
+                        status_df.loc[status_df["Candidate"] == cand, "Status"] = (
+                            status + tied_str
+                        )
                         status_df.loc[status_df["Candidate"] == cand, "Round"] = round
 
         return status_df

--- a/src/votekit/elections/__init__.py
+++ b/src/votekit/elections/__init__.py
@@ -12,7 +12,7 @@ from .election_types import (  # noqa
     Plurality,
     IRV,
     HighestScore,
-    Cumulative
+    Cumulative,
 )
 
 from .transfers import seqRCV_transfer, fractional_transfer, random_transfer  # noqa

--- a/src/votekit/elections/election_types.py
+++ b/src/votekit/elections/election_types.py
@@ -19,9 +19,8 @@ from ..utils import (
     compute_scores_from_vector,
     validate_score_vector,
     borda_scores,
-    ballots_by_first_cand
+    ballots_by_first_cand,
 )
-
 
 
 class STV(Election):
@@ -47,11 +46,11 @@ class STV(Election):
                     Defaults to True.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -119,11 +118,13 @@ class STV(Election):
 
         # if number of remaining candidates equals number of remaining seats,
         # everyone is elected
-        if len(remaining) == self.seats - len([c for s in self.state.winners() for c in s]):
+        if len(remaining) == self.seats - len(
+            [c for s in self.state.winners() for c in s]
+        ):
             elected = [{cand} for cand, _ in round_votes]
             remaining = []
             ballots = []
-        
+
         # elect all candidates who crossed threshold
         elif round_votes[0].votes >= self.threshold:
             # partition ballots by first place candidate
@@ -140,14 +141,13 @@ class STV(Election):
                         plurality_score,
                         self.threshold,
                     )
-            
+
             # add in remaining ballots where non-winners are first
             for cand in remaining:
                 new_ballots += cand_to_ballot[cand]
 
             # remove winners from all ballots
-            ballots = remove_cand([c for s in elected for c in s],new_ballots)
-            
+            ballots = remove_cand([c for s in elected for c in s], new_ballots)
 
         # since no one has crossed threshold, eliminate one of the people
         # with least first place votes
@@ -165,9 +165,10 @@ class STV(Election):
                     tiebreak=self.tiebreak,
                 )[-1]
             else:
-                lp_cand = self.tiebreak(ranking=[set(lp_candidates)],
-                    profile=self.state.profile)[-1]
-                
+                lp_cand = self.tiebreak(
+                    ranking=[set(lp_candidates)], profile=self.state.profile
+                )[-1]
+
             eliminated.append(lp_cand)
             ballots = remove_cand(lp_cand, ballots)
             remaining.remove(next(iter(lp_cand)))
@@ -176,9 +177,11 @@ class STV(Election):
         _, score_dict = compute_votes(remaining, ballots)
         remaining = scores_into_set_list(score_dict, remaining)
 
-        # sort candidates by vote share if multiple are elected    
+        # sort candidates by vote share if multiple are elected
         if len(elected) >= 1:
-            elected = scores_into_set_list(plurality_score, [c for s in elected for c in s])
+            elected = scores_into_set_list(
+                plurality_score, [c for s in elected for c in s]
+            )
 
         # Make sure list-of-sets have non-empty elements
         elected = [s for s in elected if s != set()]
@@ -236,11 +239,11 @@ class Limited(Election):
                     Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -306,7 +309,7 @@ class Limited(Election):
             )
         else:
             ranking = self.tiebreak(ranking=ranking, profile=self.state.profile)
-            
+
         elected, eliminated = elect_cands_from_set_ranking(
             ranking=ranking, seats=self.seats
         )
@@ -353,11 +356,11 @@ class Bloc(Election):
                     Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -421,11 +424,11 @@ class SNTV(Election):
                     Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -492,11 +495,11 @@ class SNTV_STV_Hybrid(Election):
                     Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -611,11 +614,11 @@ class TopTwo(Election):
                     Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -745,11 +748,11 @@ class CondoBorda(Election):
                 Defaults to True.
 
      `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -782,8 +785,10 @@ class CondoBorda(Election):
                 ranking=dominating_tiers, profile=self.state.profile, tiebreak="borda"
             )
         else:
-            ranking = self.tiebreak(ranking=dominating_tiers, profile=self.state.profile)
-            
+            ranking = self.tiebreak(
+                ranking=dominating_tiers, profile=self.state.profile
+            )
+
         elected, eliminated = elect_cands_from_set_ranking(
             ranking=ranking, seats=self.seats
         )
@@ -830,11 +835,11 @@ class SequentialRCV(Election):
                 Defaults to True.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -927,11 +932,11 @@ class Borda(Election):
                     Defaults to True.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -1016,6 +1021,7 @@ class Plurality(SNTV):
         self.seats = seats
         self.tiebreak = tiebreak
 
+
 class IRV(STV):
     """
     A class for conducting IRV elections, which are mathematically equivalent to STV for one seat.
@@ -1034,11 +1040,11 @@ class IRV(STV):
                     Defaults to True.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
     """
 
@@ -1050,14 +1056,19 @@ class IRV(STV):
         tiebreak: Union[Callable, str] = "random",
     ):
         # let parent class handle the construction
-        super().__init__(profile = profile, ballot_ties = ballot_ties,
-                         seats = 1, tiebreak = tiebreak, quota = quota,
-                         transfer=fractional_transfer)
+        super().__init__(
+            profile=profile,
+            ballot_ties=ballot_ties,
+            seats=1,
+            tiebreak=tiebreak,
+            quota=quota,
+            transfer=fractional_transfer,
+        )
 
 
 class HighestScore(Election):
     """
-    Conducts an election based on points from score vector. 
+    Conducts an election based on points from score vector.
     Chooses the m candidates with highest scores.
     Ties are broken by randomly permuting the tied candidates.
 
@@ -1074,25 +1085,28 @@ class HighestScore(Election):
         ranked in position i.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     `ballot_ties` (optional)
     : resolves ties in ballots. Should only be set to True if you want ballots
         to have full linear rankings.
 
-    
+
     """
 
-    def __init__(self, profile: PreferenceProfile, 
-                 seats: int, 
-                 score_vector: list[float],
-                 tiebreak: Union[Callable, str]= "random", 
-                 ballot_ties: bool = False):
+    def __init__(
+        self,
+        profile: PreferenceProfile,
+        seats: int,
+        score_vector: list[float],
+        tiebreak: Union[Callable, str] = "random",
+        ballot_ties: bool = False,
+    ):
         super().__init__(profile, ballot_ties)
         # check for valid score vector
         validate_score_vector(score_vector)
@@ -1101,38 +1115,42 @@ class HighestScore(Election):
         self.score_vector = score_vector
         self.tiebreak = tiebreak
 
- 
     def run_step(self):
         # a dictionary whose keys are candidates and values are scores
-        vote_tallies = compute_scores_from_vector(profile=self.state.profile, 
-                                                  score_vector=self.score_vector)
+        vote_tallies = compute_scores_from_vector(
+            profile=self.state.profile, score_vector=self.score_vector
+        )
 
         # translate scores into ranking of candidates, tie break
-        ranking = scores_into_set_list(score_dict = vote_tallies)
+        ranking = scores_into_set_list(score_dict=vote_tallies)
 
         if isinstance(self.tiebreak, str):
-            untied_ranking = tie_broken_ranking(ranking = ranking, profile = self.state.profile,
-                                     tiebreak=self.tiebreak)
+            untied_ranking = tie_broken_ranking(
+                ranking=ranking, profile=self.state.profile, tiebreak=self.tiebreak
+            )
         else:
-            untied_ranking = self.tiebreak(ranking = ranking, profile = self.state.profile)
+            untied_ranking = self.tiebreak(ranking=ranking, profile=self.state.profile)
 
         elected, eliminated = elect_cands_from_set_ranking(
             ranking=untied_ranking, seats=self.seats
         )
 
-        self.state = ElectionState(curr_round = 1,
-                                   elected = elected,
-                                   eliminated_cands = eliminated,
-                                   remaining = [],
-                                   profile = self.state.profile,
-                                   previous= self.state)
-        return(self.state)
+        self.state = ElectionState(
+            curr_round=1,
+            elected=elected,
+            eliminated_cands=eliminated,
+            remaining=[],
+            profile=self.state.profile,
+            previous=self.state,
+        )
+        return self.state
 
     @lru_cache
     def run_election(self):
         self.run_step()
         return self.state
-    
+
+
 class Cumulative(HighestScore):
     """
     Voting system where voters are allowed to vote for candidates with multiplicity.
@@ -1151,11 +1169,11 @@ class Cumulative(HighestScore):
                     Defaults to True.
 
     `tiebreak`
-    :   (optional) resolves procedural and final ties by specified tiebreak. 
-                    Can either be a custom tiebreak function or a string. Supported strings are 
-                    given in `tie_broken_ranking` documentation. The custom function must take as 
-                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and 
-                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets 
+    :   (optional) resolves procedural and final ties by specified tiebreak.
+                    Can either be a custom tiebreak function or a string. Supported strings are
+                    given in `tie_broken_ranking` documentation. The custom function must take as
+                    input two named parameters; `ranking`, a list-of-sets ranking of candidates and
+                    `profile`, the original `PreferenceProfile`. It must return a list-of-sets
                     ranking of candidates with no ties. Defaults to random tiebreak.
 
     **Methods**
@@ -1168,16 +1186,16 @@ class Cumulative(HighestScore):
         ballot_ties: bool = True,
         tiebreak: Union[str, Callable] = "random",
     ):
-        
         longest_ballot = 0
         for ballot in profile.ballots:
             if len(ballot.ranking) > longest_ballot:
                 longest_ballot = len(ballot.ranking)
 
         score_vector = [1.0 for _ in range(longest_ballot)]
-        super().__init__(profile = profile, 
-                         ballot_ties = ballot_ties, 
-                         score_vector = score_vector,
-                         seats = seats,
-                         tiebreak = tiebreak)
-        
+        super().__init__(
+            profile=profile,
+            ballot_ties=ballot_ties,
+            score_vector=score_vector,
+            seats=seats,
+            tiebreak=tiebreak,
+        )

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -6,8 +6,10 @@ from functools import cache
 from typing import Callable
 import matplotlib.pyplot as plt
 
+
 def all_nodes(graph, node):
     return True
+
 
 class BallotGraph(Graph):
     """
@@ -34,7 +36,7 @@ class BallotGraph(Graph):
         self,
         source: Union[PreferenceProfile, int, list],
         allow_partial: Optional[bool] = True,
-        fix_short: Optional[bool] = True
+        fix_short: Optional[bool] = True,
     ):
         super().__init__()
 
@@ -58,7 +60,7 @@ class BallotGraph(Graph):
             self.allow_partial = True
             if not self.graph:
                 self.graph = self.build_graph(len(source.get_candidates()))
-            self.graph = self.from_profile(source, fix_short = fix_short)
+            self.graph = self.from_profile(source, fix_short=fix_short)
 
         self.num_voters = sum(self.node_weights.values())
 
@@ -139,8 +141,7 @@ class BallotGraph(Graph):
         return Gc
 
     def from_profile(
-        self, profile: PreferenceProfile,
-        fix_short: Optional[bool] = True
+        self, profile: PreferenceProfile, fix_short: Optional[bool] = True
     ) -> nx.Graph:
         """
         Updates existing graph based on cast ballots from a PreferenceProfile,
@@ -202,14 +203,13 @@ class BallotGraph(Graph):
 
         return ballot + list(missing)
 
-    def label_cands(self, candidates,
-                    to_display: Callable = all_nodes):
+    def label_cands(self, candidates, to_display: Callable = all_nodes):
         """
         Assigns candidate labels to ballot graph for plotting.
 
         Args:
-            candidates (list): A list of candidates. 
-            to_display: A Boolean callable that takes in a graph and node, 
+            candidates (list): A list of candidates.
+            to_display: A Boolean callable that takes in a graph and node,
                         returns True if node should be displayed.
         """
 
@@ -223,10 +223,11 @@ class BallotGraph(Graph):
                 ballot = []
                 for num in node:
                     ballot.append(cand_dict[num])
-                
+
                 # label the ballot and give the number of votes
-                cand_labels[node] = str(tuple(ballot))+": " + \
-                                str(self.graph.nodes[node]["weight"])
+                cand_labels[node] = (
+                    str(tuple(ballot)) + ": " + str(self.graph.nodes[node]["weight"])
+                )
 
         return cand_labels
 
@@ -236,16 +237,17 @@ class BallotGraph(Graph):
         Only shows weight if non-zero.
 
         Args:
-            to_display: A Boolean callable that takes in a graph and node, 
+            to_display: A Boolean callable that takes in a graph and node,
                         returns True if node should be displayed.
         """
         node_labels = {}
         for node in self.graph.nodes:
             if to_display(self.graph, node):
                 # label the ballot and give the number of votes
-                if self.graph.nodes[node]["weight"] >0:
-                    node_labels[node] = str(node)+": " + \
-                                str(self.graph.nodes[node]["weight"])
+                if self.graph.nodes[node]["weight"] > 0:
+                    node_labels[node] = (
+                        str(node) + ": " + str(self.graph.nodes[node]["weight"])
+                    )
                 else:
                     node_labels[node] = str(node)
 
@@ -262,15 +264,18 @@ class BallotGraph(Graph):
 
         return legend
 
-    def draw(self, to_display: Callable = all_nodes,
-             neighborhoods: Optional[list[tuple]] = [],
-             show_cast: Optional[bool] = False,
-             labels: Optional[bool] = False):
+    def draw(
+        self,
+        to_display: Callable = all_nodes,
+        neighborhoods: Optional[list[tuple]] = [],
+        show_cast: Optional[bool] = False,
+        labels: Optional[bool] = False,
+    ):
         """
         Visualize the graph.
 
         Args:
-            to_display: A boolean function that takes the graph and a node as input, 
+            to_display: A boolean function that takes the graph and a node as input,
                 returns True if you want that node displayed. Defaults to showing all nodes.
             neighborhoods: A list of neighborhoods to display, given as tuple (node, radius).
                             (ex. (n,1) gives all nodes within one step of n).
@@ -278,19 +283,18 @@ class BallotGraph(Graph):
                         If False, show all nodes.
             labels: If True, labels nodes with candidate names and vote totals.
         """
-        
 
         def cast_nodes(graph, node):
             return graph.nodes[node]["cast"]
-        
+
         def in_neighborhoods(graph, node):
             centers = [node for node, radius in neighborhoods]
             radii = [radius for node, radius in neighborhoods]
 
             distances = [nx.shortest_path_length(graph, node, x) for x in centers]
 
-            return (True in [d <= r for d,r in zip(distances, radii)])
-        
+            return True in [d <= r for d, r in zip(distances, radii)]
+
         if show_cast:
             to_display = cast_nodes
 
@@ -299,7 +303,6 @@ class BallotGraph(Graph):
 
         ballots = [n for n in self.graph.nodes if to_display(self.graph, n)]
 
-
         if labels:
             if not self.candidates:
                 raise ValueError("no candidate names assigned")
@@ -307,20 +310,19 @@ class BallotGraph(Graph):
 
         else:
             node_labels = self.label_weights(to_display)
-            
+
             # if not labeling the nodes with candidates and graph is drawn from profile,
             # print labeling dictionary
             if self.profile and self.candidates:
                 print("The candidates are labeled as follows.")
-                cand_dict = self._number_cands(cands = tuple(self.candidates))
-                for cand,value in cand_dict.items():
-                    print(value,cand)
-            
+                cand_dict = self._number_cands(cands=tuple(self.candidates))
+                for cand, value in cand_dict.items():
+                    print(value, cand)
+
         subgraph = self.graph.subgraph(ballots)
 
         pos = nx.spring_layout(subgraph)
-        nx.draw_networkx(subgraph, pos = pos, 
-                         with_labels=True, labels=node_labels)
+        nx.draw_networkx(subgraph, pos=pos, with_labels=True, labels=node_labels)
 
         # handles labels overlapping with margins
         x_values, y_values = zip(*pos.values())
@@ -331,10 +333,6 @@ class BallotGraph(Graph):
         plt.xlim(x_min - x_margin, x_max + x_margin)
         plt.ylim(y_min - y_margin, y_max + y_margin)
         plt.show()
-
-       
-
-
 
     # what are these functions supposed to do?
     # def compare(self, new_pref: PreferenceProfile, dist_type: Callable):

--- a/src/votekit/graphs/pairwise_comparison_graph.py
+++ b/src/votekit/graphs/pairwise_comparison_graph.py
@@ -44,7 +44,7 @@ class PairwiseComparisonGraph(Graph):
             ballot_length: How long a ballot is.
 
         Returns:
-            PreferenceProfile (PreferenceProfile): A PreferenceProfile with incomplete 
+            PreferenceProfile (PreferenceProfile): A PreferenceProfile with incomplete
                 ballots filled in.
         """
         cand_list = [{cand} for cand in profile.get_candidates()]
@@ -72,7 +72,7 @@ class PairwiseComparisonGraph(Graph):
     # Helper functions to make pairwise comparison graph
     def head2head_count(self, cand1, cand2) -> Fraction:
         """
-        Counts head to head comparisons between two candidates. Note that the given order 
+        Counts head to head comparisons between two candidates. Note that the given order
         of the candidates matters here.
 
         Args:
@@ -170,7 +170,7 @@ class PairwiseComparisonGraph(Graph):
         )
         edge_labels = {(i, j): G[i][j]["weight"] for i, j in G.edges()}
         nx.draw_networkx_edge_labels(
-            G, pos, edge_labels=edge_labels, label_pos=1/3, font_size=10
+            G, pos, edge_labels=edge_labels, label_pos=1 / 3, font_size=10
         )
         # Out stuff
         if outfile is not None:
@@ -191,7 +191,7 @@ class PairwiseComparisonGraph(Graph):
         if len(dominating_tiers[0]) == 1:
             return True
         return False
-    
+
     def get_condorcet_winner(self) -> str:
         """
         Returns the condorcet winner. Raises a ValueError if no condorcet winner.
@@ -199,7 +199,7 @@ class PairwiseComparisonGraph(Graph):
         Returns:
             The condorcet winner.
         """
-        
+
         if self.has_condorcet_winner():
             return list(self.dominating_tiers()[0])[0]
 
@@ -260,4 +260,4 @@ class PairwiseComparisonGraph(Graph):
 
         G = self.pairwise_graph
         list_of_cycles = nx.recursive_simple_cycles(G)
-        return(sorted(list_of_cycles, key=lambda x: len(x)))
+        return sorted(list_of_cycles, key=lambda x: len(x))

--- a/src/votekit/metrics/distances.py
+++ b/src/votekit/metrics/distances.py
@@ -54,7 +54,7 @@ def lp_dist(
     Args:
         pp1: PreferenceProfile for first election.
         pp2: PreferenceProfile for second election.
-        p_value: Distance parameter, 1 for Manhattan, 2 for Euclidean 
+        p_value: Distance parameter, 1 for Manhattan, 2 for Euclidean
             or 'inf' for Chebyshev distance.
 
     Returns:
@@ -86,7 +86,7 @@ def lp_dist(
 def profiles_to_ndarrys(profiles: list[PreferenceProfile]):
     """
     Converts a list of PreferenceProfile into an ndarray,
-    a matrix like object. The cols represent each profile, 
+    a matrix like object. The cols represent each profile,
     rows are the cast ballots, and each element represents
     the frequency a ballot type occurs for a PreferenceProfile.
     Each column will sum to one since weights are standardized.

--- a/src/votekit/models.py
+++ b/src/votekit/models.py
@@ -31,7 +31,6 @@ class Election(ABC):
 
         self.state = ElectionState(curr_round=0, profile=self._profile)
 
-
     def run_to_step(self, step: int):
         """
         Run the election to the given step.
@@ -54,9 +53,9 @@ class Election(ABC):
                     if self.state.previous:
                         self.state = self.state.previous
                     else:
-                        raise ValueError("Previous state is None type.") 
+                        raise ValueError("Previous state is None type.")
 
-            return(self.state)
+            return self.state
 
     @abstractmethod
     def run_step(self, *args: Any, **kwargs: Any):

--- a/src/votekit/plots/mds.py
+++ b/src/votekit/plots/mds.py
@@ -5,6 +5,7 @@ import numpy as np
 from typing import Dict
 from sklearn import manifold  # type: ignore
 
+
 # Helper function for MDS Plot
 def distance_matrix(
     pp_arr: list[PreferenceProfile], distance: Callable[..., int], *args, **kwargs

--- a/src/votekit/plots/profile_plots.py
+++ b/src/votekit/plots/profile_plots.py
@@ -35,9 +35,9 @@ def plot_summary_stats(
 
     fig, ax = plt.subplots()
 
-    candidates = profile.get_candidates(received_votes = False)
+    candidates = profile.get_candidates(received_votes=False)
     y_data = [data[c] for c in candidates]
-    
+
     ax.bar(candidates, y_data, color=colors, width=0.35)
     ax.set_xlabel("Candidates")
     ax.set_ylabel("Frequency")

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -215,10 +215,9 @@ class PreferenceProfile(BaseModel):
             df["New Index"] = [x for x in range(len(self.df) - 1, -1, -1)]
             df = df.set_index("New Index").head(n)
             df.index.name = None
-            
+
         else:
             df = self.df.iloc[::-1].head(n)
-
 
         if totals:
             df = self._sum_row(df)
@@ -273,7 +272,7 @@ class PreferenceProfile(BaseModel):
                 Ballot(ranking=ranking, weight=Fraction(total_weight))
             )
 
-        condensed_profile = PreferenceProfile(ballots = new_ballot_list)
+        condensed_profile = PreferenceProfile(ballots=new_ballot_list)
         return condensed_profile
 
     def __eq__(self, other):
@@ -312,9 +311,11 @@ class PreferenceProfile(BaseModel):
         Add two PreferenceProfiles by combining their ballot lists.
         """
         if isinstance(other, PreferenceProfile):
-            ballots = self.ballots+other.ballots
+            ballots = self.ballots + other.ballots
             pp = PreferenceProfile(ballots=ballots)
             pp.condense_ballots()
             return pp
         else:
-            raise TypeError("Unsupported operand type. Must be an instance of PreferenceProfile.")
+            raise TypeError(
+                "Unsupported operand type. Must be an instance of PreferenceProfile."
+            )

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -30,27 +30,29 @@ COLOR_LIST = [
 # Election Helper Functions
 CandidateVotes = namedtuple("CandidateVotes", ["cand", "votes"])
 
-def ballots_by_first_cand(candidates:list[str], ballots: list[Ballot]) -> dict:
+
+def ballots_by_first_cand(candidates: list[str], ballots: list[Ballot]) -> dict:
     """
-    Partitions the ballots by first place candidate. 
+    Partitions the ballots by first place candidate.
 
     Returns:
         A dictionary whose keys are candidates and values are lists of ballots.
     """
-    cand_dict = {c:[] for c in candidates} # type: dict
+    cand_dict = {c: [] for c in candidates}  # type: dict
 
     for b in ballots:
         if b.ranking:
             # find first place candidate, ensure there is only one
             first_cand = list(b.ranking[0])
-            if len(first_cand)>1:
+            if len(first_cand) > 1:
                 raise ValueError(f"Ballot {b} has a tie for first.")
             else:
                 first_cand = first_cand[0]
 
             cand_dict[first_cand].append(b)
-        
+
     return cand_dict
+
 
 def compute_votes(
     candidates: list,
@@ -64,8 +66,8 @@ def compute_votes(
         ballots: List of Ballot objects.
 
     Returns:
-        A tuple (ordered, votes) where ordered is a list of tuples (cand, first place votes) 
-            ordered by decreasing first place votes and votes is a dictionary whose keys are 
+        A tuple (ordered, votes) where ordered is a list of tuples (cand, first place votes)
+            ordered by decreasing first place votes and votes is a dictionary whose keys are
             candidates and values are first place votes.
     """
     votes = {cand: Fraction(0) for cand in candidates}
@@ -141,8 +143,7 @@ def remove_cand(removed: Union[str, Iterable], ballots: list[Ballot]) -> list[Ba
 
 
 # Summmary Stat functions
-def first_place_votes(profile: PreferenceProfile,
-                      to_float: bool = False) -> dict:
+def first_place_votes(profile: PreferenceProfile, to_float: bool = False) -> dict:
     """
     Calculates first-place votes for a PreferenceProfile.
 
@@ -161,7 +162,7 @@ def first_place_votes(profile: PreferenceProfile,
     _, votes_dict = compute_votes(cands, ballots)
 
     if to_float:
-        votes_dict = {k:float(v) for k,v in votes_dict.items()}
+        votes_dict = {k: float(v) for k, v in votes_dict.items()}
         return votes_dict
     else:
         return votes_dict
@@ -217,7 +218,6 @@ def borda_scores(
         ballot_length = max([len(ballot.ranking) for ballot in profile.ballots])
     if score_vector is None:
         score_vector = list(range(ballot_length, 0, -1))
-
 
     print(score_vector)
     candidate_borda = {c: Fraction(0) for c in candidates}
@@ -362,7 +362,10 @@ def scores_into_set_list(
         ]
     return tier_list
 
-def compute_scores_from_vector(profile: PreferenceProfile, score_vector: list[float]) -> dict:
+
+def compute_scores_from_vector(
+    profile: PreferenceProfile, score_vector: list[float]
+) -> dict:
     """
     Computes the scores received by each candidate given the score vector and the profile.
 
@@ -378,20 +381,24 @@ def compute_scores_from_vector(profile: PreferenceProfile, score_vector: list[fl
     # check for valid score vector
     validate_score_vector(score_vector)
 
-    candidates_to_scores = {c:0.0 for c in profile.get_candidates()}
+    candidates_to_scores = {c: 0.0 for c in profile.get_candidates()}
 
     for ballot in profile.ballots:
         for i, s in enumerate(ballot.ranking):
             # for each candidate in position i, give them points as determined by score_vector
             for c in s:
                 try:
-                    candidates_to_scores[c] += score_vector[i]*ballot.weight
+                    candidates_to_scores[c] += score_vector[i] * ballot.weight
                 except IndexError:
-                    warnings.warn(f"Tried to access index {i} of score vector," 
-                                     f"but vector only length {len(score_vector)}. "
-                                     "Assigned candidate 0 points.", UserWarning)
+                    warnings.warn(
+                        f"Tried to access index {i} of score vector,"
+                        f"but vector only length {len(score_vector)}. "
+                        "Assigned candidate 0 points.",
+                        UserWarning,
+                    )
 
-    return(candidates_to_scores)
+    return candidates_to_scores
+
 
 def validate_score_vector(score_vector: list[float]):
     """
@@ -403,11 +410,11 @@ def validate_score_vector(score_vector: list[float]):
         if score < 0:
             raise ValueError("Score vector must be non-negative.")
 
-        if i>0:
+        if i > 0:
             # if the current score is bigger than prev
-            if score > score_vector[i-1]:
+            if score > score_vector[i - 1]:
                 raise ValueError("Score vector must be non-increasing.")
-        
+
 
 def elect_cands_from_set_ranking(
     ranking: list[set[str]], seats: int

--- a/tests/test_ballot_generator.py
+++ b/tests/test_ballot_generator.py
@@ -64,6 +64,13 @@ def test_SP_completion():
     profile = pl.generate_profile(number_of_ballots=100)
     assert type(profile) is PreferenceProfile
 
+    result = pl.generate_profile(number_of_ballots=100, by_bloc=True)
+    assert type(result) is tuple
+    profile_dict, agg_prof = result
+    assert type(profile_dict) is dict
+    assert(type(profile_dict["W"])) is PreferenceProfile
+    assert type(agg_prof) is PreferenceProfile
+
 def test_BT_completion():
     bt = BradleyTerry(
         candidates=["W1", "W2", "C1", "C2"],
@@ -606,16 +613,15 @@ def test_incorrect_blocs():
 
 def test_ac_profile_from_params():
     blocs = {"R": 0.6, "D": 0.4}
-    cohesion = {"R": 0.7, "D": 0.6}
+    # cohesion = {"R": 0.7, "D": 0.6}
     alphas = {"R": {"R": 0.5, "D": 1}, "D": {"R": 1, "D": 0.5}}
     cohesion_parameters = {"R": 0.5, "D": 0.4}
     slate_to_cands = {"R": ["A1", "B1", "C1"], "D": ["A2", "B2"]}
     ac = AlternatingCrossover.from_params(
         bloc_voter_prop=blocs,
-        cohesion=cohesion,
         alphas=alphas,
         slate_to_candidates=slate_to_cands,
-        cohesion_parameters=cohesion_parameters,
+        cohesion=cohesion_parameters,
     )
 
     profile = ac.generate_profile(3)

--- a/tests/test_ballot_generator.py
+++ b/tests/test_ballot_generator.py
@@ -15,6 +15,7 @@ from votekit.ballot_generator import (
     CambridgeSampler,
     OneDimSpatial,
     BallotSimplex,
+    SlatePreference
 )
 from votekit.pref_profile import PreferenceProfile
 
@@ -48,7 +49,20 @@ def test_PL_completion():
     )
     profile = pl.generate_profile(number_of_ballots=100)
     assert type(profile) is PreferenceProfile
-
+    
+def test_SP_completion():
+    pl = SlatePreference(
+        candidates=["W1", "W2", "C1", "C2"],
+        slate_to_candidates={"W": ["W1", "W2"], "C": ["C1", "C2"]},
+        pref_interval_by_bloc={
+            "W": {"W1": 0.4, "W2": 0.3, "C1": 0.2, "C2": 0.1},
+            "C": {"W1": 0.2, "W2": 0.2, "C1": 0.3, "C2": 0.3},
+        },
+        bloc_voter_prop={"W": 0.7, "C": 0.3},
+        cohesion_parameters={"W": 0.7, "C": 0.9},
+    )
+    profile = pl.generate_profile(number_of_ballots=100)
+    assert type(profile) is PreferenceProfile
 
 def test_BT_completion():
     bt = BradleyTerry(
@@ -269,6 +283,68 @@ def test_PL_distribution():
         ballot_prob_dict, generated_profile, len(candidates)
     )
 
+def test_SP_distribution():
+    # Set-up
+    number_of_ballots = 500
+    candidates = ["W1", "W2", "C1", "C2"]
+    pref_interval_by_bloc = {
+        "W": {"W1": 0.4, "W2": 0.3, "C1": 0.2, "C2": 0.1},
+        "C": {"W1": 0.2, "W2": 0.2, "C1": 0.3, "C2": 0.3},
+    }
+    bloc_voter_prop = {"W": 0.7, "C": 0.3}
+    cohesion = {"W": .9, "C": .8}
+    slate_to_candidates = {"W": ["W1", "W2"],
+                           "C": ["C1", "C2"]}
+    
+    # Generate ballots
+    generated_profile_by_bloc, _ = SlatePreference(
+        candidates=candidates,
+        pref_interval_by_bloc=pref_interval_by_bloc,
+        bloc_voter_prop=bloc_voter_prop,
+        cohesion_parameters=cohesion,
+        slate_to_candidates=slate_to_candidates
+    ).generate_profile(number_of_ballots=number_of_ballots, by_bloc=True)
+
+    blocs = list(bloc_voter_prop.keys())
+    
+    # Find labeled ballot probs
+    possible_rankings = list(it.permutations(candidates))
+    for current_bloc in blocs:
+        ballot_prob_dict = {b: 0 for b in possible_rankings}
+        
+        for ranking in possible_rankings:
+            support_for_cands = pref_interval_by_bloc[current_bloc]
+            total_prob = 1
+            prob = 1
+            for cand in ranking:
+                prob *= support_for_cands[cand] / total_prob
+                total_prob -= support_for_cands[cand]
+            ballot_prob_dict[ranking] += prob
+
+
+        candidate_to_slate = {c:s for s,c_list in slate_to_candidates.items() for c in c_list}
+        # now compute unlabeled ballot probs and multiply by labeled ballot probs
+        for ballot in ballot_prob_dict.keys():
+            # relabel candidates by their bloc
+            ballot_by_bloc = [candidate_to_slate[c] for c in ballot]
+            prob = 1
+            bloc_counter = {b:0 for b in bloc_voter_prop.keys()}
+            # compute prob of ballot type
+            for bloc in ballot_by_bloc:
+                prob *= cohesion[bloc]
+                bloc_counter[bloc] += 1
+
+                # TODO only works with two blocs
+                # if no more of current bloc, rest of ballot is determined
+                if bloc_counter[bloc] == len(slate_to_candidates[bloc]):
+                    break
+            
+            ballot_prob_dict[ballot] *= prob
+
+        # Test
+        assert do_ballot_probs_match_ballot_dist(
+            ballot_prob_dict, generated_profile_by_bloc[current_bloc], len(candidates)
+        )
 
 def test_BT_distribution():
 


### PR DESCRIPTION
This PR adds a new model of ballot generator, the SlatePreference model, as well as two tests for the test suite.

1. The SlatePreference model uses the cohesion parameter of a voter to determine their ballot type; a coin weighted by the cohesion parameter is flipped repeatedly, determining the order of the slates on the ballot. The candidate names are then filled in in a PL style.
2. Added completion and distribution tests for the SP model.

@jamesturk @drdeford @jgibson517 @jennjwang @ziglaser