### PR TITLE
Use max_ballot length in Borda functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ dependencies = [
     "numpy (>=1.26.0, <2.0)",
 ]
 
-#[tool.poetry.dependencies]
-#python = "
- 
+
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.0.275"
 black = "^24.8.0"
@@ -35,9 +33,6 @@ sphinx-copybutton = "^0.5.2"
 recommonmark = "^0.7.1"
 sphinx-rtd-theme = "^3.0.2"
 
-#[build-system]
-#requires = ["poetry-core"]
-#build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 line-length = 100

--- a/src/votekit/elections/election_types/ranking/borda.py
+++ b/src/votekit/elections/election_types/ranking/borda.py
@@ -17,8 +17,8 @@ class Borda(RankingElection):
     Borda election. Positional voting system that assigns a decreasing number of points to
     candidates based on their ordering. The conventional score vector is :math:`(n, n-1, \dots, 1)`
     where :math:`n` is the ``max_ballot_length`` of the profile. Candidates with the highest scores
-    This class uses the `utils.score_profile_from_rankings()` to handle ballots with ties and
-    missing candidates.
+    are elected. This class uses the ``utils.score_profile_from_rankings()`` to handle ballots with
+    ties.
 
     Args:
         profile (PreferenceProfile): Profile to conduct election on.

--- a/src/votekit/elections/election_types/ranking/borda.py
+++ b/src/votekit/elections/election_types/ranking/borda.py
@@ -16,7 +16,7 @@ class Borda(RankingElection):
     r"""
     Borda election. Positional voting system that assigns a decreasing number of points to
     candidates based on their ordering. The conventional score vector is :math:`(n, n-1, \dots, 1)`
-    where :math:`n` is the number of candidates. Candidates with the highest scores are elected.
+    where :math:`n` is the ``max_ballot_length`` of the profile. Candidates with the highest scores
     This class uses the `utils.score_profile_from_rankings()` to handle ballots with ties and
     missing candidates.
 

--- a/src/votekit/elections/election_types/ranking/borda.py
+++ b/src/votekit/elections/election_types/ranking/borda.py
@@ -48,7 +48,7 @@ class Borda(RankingElection):
         self.m = m
         self.tiebreak = tiebreak
         if not score_vector:
-            score_vector = list(range(len(profile.candidates), 0, -1))
+            score_vector = list(range(profile.max_ballot_length, 0, -1))
 
         validate_score_vector(score_vector)
         self.score_vector = score_vector

--- a/src/votekit/plots/mds.py
+++ b/src/votekit/plots/mds.py
@@ -41,7 +41,7 @@ def compute_MDS(
     distance: Callable[..., int],
     random_seed: int = 47,
     *args,
-    **kwargs
+    **kwargs,
 ):
     """
     Computes the coordinates of an MDS plot. This is time intensive, so it is decoupled from

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -253,7 +253,7 @@ def score_profile_from_rankings(
     """
     Score the candidates based on a score vector. For example, the vector (1,0,...) would
     return the first place votes for each candidate. Vectors should be non-increasing and
-    non-negative. Vector should be as long as the number of candidates. If it is shorter,
+    non-negative. Vector should be as long as ``max_ballot_length`` in the profile.
     If it is shorter, we add 0s. Unlisted candidates receive 0 points.
 
 
@@ -261,7 +261,7 @@ def score_profile_from_rankings(
         profile (PreferenceProfile): Profile to score.
         score_vector (Sequence[Union[float, Fraction]]): Score vector. Should be
             non-increasing and non-negative. Vector should be as long as ``max_ballot_length`` in
-            If it is shorter, we add 0s.
+            the profile. If it is shorter, we add 0s.
         to_float (bool, optional): If True, compute scores as floats instead of Fractions.
             Defaults to False.
         tie_convention (Literal["high", "average", "low"], optional): How to award points for

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -278,7 +278,7 @@ def score_profile_from_rankings(
     """
     validate_score_vector(score_vector)
 
-    max_length = len(profile.candidates)
+    max_length = profile.max_ballot_length
     if len(score_vector) < max_length:
         score_vector = list(score_vector) + [0] * (max_length - len(score_vector))
 
@@ -340,7 +340,7 @@ def first_place_votes(
     """
     # equiv to score vector of (1,0,0,...)
     return score_profile_from_rankings(
-        profile, [1] + [0] * len(profile.candidates), to_float, tie_convention
+        profile, [1] + [0] * (profile.max_ballot_length - 1), to_float, tie_convention
     )
 
 

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -183,8 +183,7 @@ def remove_cand(
 def add_missing_cands(profile: PreferenceProfile) -> PreferenceProfile:
     """
     Add any candidates from `profile.candidates` that are not listed on a ballot
-    as tied in last place. Helper function for scoring profiles. Automatically
-    condenses profile.
+    as tied in last place. Automatically condenses profile.
 
     Args:
         profile (PreferenceProfile): Input profile.
@@ -255,13 +254,13 @@ def score_profile_from_rankings(
     Score the candidates based on a score vector. For example, the vector (1,0,...) would
     return the first place votes for each candidate. Vectors should be non-increasing and
     non-negative. Vector should be as long as the number of candidates. If it is shorter,
-    we add 0s. Unlisted candidates receive 0 points.
+    If it is shorter, we add 0s. Unlisted candidates receive 0 points.
 
 
     Args:
         profile (PreferenceProfile): Profile to score.
         score_vector (Sequence[Union[float, Fraction]]): Score vector. Should be
-            non-increasing and non-negative. Vector should be as long as the number of candidates.
+            non-increasing and non-negative. Vector should be as long as ``max_ballot_length`` in
             If it is shorter, we add 0s.
         to_float (bool, optional): If True, compute scores as floats instead of Fractions.
             Defaults to False.
@@ -382,9 +381,7 @@ def borda_scores(
 ) -> Union[dict[str, Fraction], dict[str, float]]:
     """
     Calculates Borda scores for a ``PreferenceProfile``. The Borda vector is
-    :math:`(n,n-1,\dots,1, 0,\dots,0)` where :math:`n` is the ``borda_max`.
-    Unlisted candidates receive 0 points.
-
+    :math:`(n,n-1,\dots,1)` where :math:`n` is the ``borda_max`.
 
     Args:
         profile (PreferenceProfile): ``PreferenceProfile`` of ballots.


### PR DESCRIPTION
Standardizes the use of `PreferenceProfile.max_ballot_length` for Borda functions, rather than number of candidates as the maximum value of the Borda vector. Cleans up doc strings to reflect this.