### PR TITLE
Update the condense_ballot() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - renamed `dominating_tiers` method of pairwise comparison graph to `get_dominating_tiers`.
 - renamed `cleaning.deduplicate_profile` to `cleaning.remove_repeated_candidates`.
 - moved `remove_cand` from `utils` to `cleaning`, and removed the older function `remove_noncands`.
+- renamed `PreferenceProfile.condense_ballots()` to `PreferenceProfile.group_ballots()`.
+
 
 
 ## Fixed
+- `PreferenceProfile.group_ballots()` now also groups the `voter_set` attribute of ballots.
 
 ## [3.1.0] - 2025-03-03
 ## Added

--- a/docs/user/tutorial/1_intro.rst
+++ b/docs/user/tutorial/1_intro.rst
@@ -285,7 +285,7 @@ profile, as follows.
 
 .. code:: ipython3
 
-    condensed_profile  = profile.condense_ballots()
+    condensed_profile  = profile.group_ballots()
     print(condensed_profile)
 
 
@@ -360,7 +360,7 @@ using the ``sort_by_weight`` parameter and setting it to ``True``.
     print()
     
     # condense and sort by by weight
-    condensed_profile = profile.condense_ballots()
+    condensed_profile = profile.group_ballots()
     print(condensed_profile.head(8,sort_by_weight=True))
 
 
@@ -686,7 +686,7 @@ it should.
     profile = PreferenceProfile(ballots = ballots*6,
                                 candidates = candidates)
     
-    profile = profile.condense_ballots()
+    profile = profile.group_ballots()
     
     print(profile)
     

--- a/notebooks/1_intro.ipynb
+++ b/notebooks/1_intro.ipynb
@@ -388,7 +388,7 @@
     }
    ],
    "source": [
-    "condensed_profile = profile.condense_ballots()\n",
+    "condensed_profile = profile.group_ballots()\n",
     "print(condensed_profile)"
    ]
   },
@@ -517,7 +517,7 @@
     "print()\n",
     "\n",
     "# condense and sort by by weight\n",
-    "condensed_profile = profile.condense_ballots()\n",
+    "condensed_profile = profile.group_ballots()\n",
     "print(condensed_profile.head(8, sort_by_weight=True))"
    ]
   },
@@ -828,7 +828,7 @@
     "\n",
     "profile = PreferenceProfile(ballots=ballots * 6, candidates=candidates)\n",
     "\n",
-    "profile = profile.condense_ballots()\n",
+    "profile = profile.group_ballots()\n",
     "\n",
     "print(profile)\n",
     "\n",

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -2,6 +2,7 @@ from fractions import Fraction
 from pydantic.dataclasses import dataclass
 from pydantic import ConfigDict, field_validator
 from typing import Optional, Union
+from dataclasses import field
 
 
 @dataclass(frozen=True, config=ConfigDict(arbitrary_types_allowed=True))
@@ -31,7 +32,7 @@ class Ballot:
 
     ranking: Optional[tuple[frozenset, ...]] = None
     weight: Fraction = Fraction(1, 1)
-    voter_set: Optional[set[str]] = None
+    voter_set: set[str] = field(default_factory=set)
     id: Optional[str] = None
     scores: Optional[dict[str, Fraction]] = None
 
@@ -83,9 +84,8 @@ class Ballot:
             return False
 
         # Check voters
-        if self.voter_set is not None:
-            if self.voter_set != other.voter_set:
-                return False
+        if self.voter_set != other.voter_set:
+            return False
 
         # Check scores
         if self.scores is not None:

--- a/src/votekit/ballot_generator.py
+++ b/src/votekit/ballot_generator.py
@@ -572,7 +572,7 @@ class short_name_PlackettLuce(BallotGenerator):
 
             # create PP for this bloc
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pp_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -821,7 +821,7 @@ class name_BradleyTerry(BallotGenerator):
                 ballot_pool[j] = Ballot(ranking=tuple(ranking), weight=Fraction(1, 1))
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pp_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -897,7 +897,7 @@ class name_BradleyTerry(BallotGenerator):
             raise ValueError("Some element of ballots list is not a ballot.")
 
         pp = PreferenceProfile(ballots=ballots)
-        pp = pp.condense_ballots()
+        pp = pp.group_ballots()
         return pp
 
     def generate_profile_MCMC(
@@ -1097,7 +1097,7 @@ class AlternatingCrossover(BallotGenerator):
                 ballot_pool.append(ballot)
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pp_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -1402,7 +1402,7 @@ class CambridgeSampler(BallotGenerator):
                 ballot_pool[i] = Ballot(ranking=ranking, weight=Fraction(1, 1))
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pp_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -1529,7 +1529,7 @@ class name_Cumulative(BallotGenerator):
                 ballot_pool.append(Ballot(scores=scores, weight=Fraction(1, 1)))
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pp_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -1657,7 +1657,7 @@ class slate_PlackettLuce(BallotGenerator):
                 ballot_pool[j] = Ballot(ranking=tuple(ranking), weight=Fraction(1, 1))
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pref_profile_by_bloc[bloc] = pp
 
         # combine the profiles
@@ -1941,7 +1941,7 @@ class slate_BradleyTerry(BallotGenerator):
                 ballot_pool[j] = Ballot(ranking=tuple(ranking), weight=Fraction(1, 1))
 
             pp = PreferenceProfile(ballots=tuple(ballot_pool))
-            pp = pp.condense_ballots()
+            pp = pp.group_ballots()
             pref_profile_by_bloc[bloc] = pp
 
         # combine the profiles

--- a/src/votekit/cleaning.py
+++ b/src/votekit/cleaning.py
@@ -74,7 +74,7 @@ def merge_ballots(ballots: list[Ballot]) -> Ballot:
     weight = sum(b.weight for b in ballots)
     ranking = ballots[0].ranking
     voters_to_merge = [b.voter_set for b in ballots if b.voter_set]
-    voter_set = None
+    voter_set = set()
     if len(voters_to_merge) > 0:
         voter_set = reduce(lambda b1, b2: b1.union(b2), voters_to_merge)
         voter_set = set(voter_set)

--- a/src/votekit/cvr_loaders.py
+++ b/src/votekit/cvr_loaders.py
@@ -180,5 +180,5 @@ def load_scottish(
 
     profile = PreferenceProfile(
         ballots=tuple(ballots), candidates=tuple(cand_list)
-    ).condense_ballots()
+    ).group_ballots()
     return (profile, seats, cand_list, cand_to_party, ward)

--- a/src/votekit/cvr_loaders.py
+++ b/src/votekit/cvr_loaders.py
@@ -78,7 +78,7 @@ def load_csv(
             [frozenset({None}) if pd.isnull(c) else frozenset({c}) for c in group]
         )
 
-        voter_set = None
+        voter_set = set()
         if id_col is not None:
             voter_set = set(group_df.iloc[:, id_col])
         weight = len(group_df)

--- a/src/votekit/elections/election_types/ranking/plurality_veto.py
+++ b/src/votekit/elections/election_types/ranking/plurality_veto.py
@@ -101,7 +101,12 @@ class PluralityVeto(RankingElection):
         bidx = 0
         for b in ballots:
             for _ in range(int(b.weight)):
-                new_ballots[bidx] = Ballot(b.ranking, weight=Fraction(1, 1))
+                new_ballots[bidx] = Ballot(
+                    b.ranking,
+                    weight=Fraction(1, 1),
+                    voter_set=b.voter_set,
+                    id=b.id,
+                )
                 bidx += 1
 
         profile = PreferenceProfile(

--- a/src/votekit/elections/transfers.py
+++ b/src/votekit/elections/transfers.py
@@ -54,7 +54,7 @@ def fractional_transfer(
         PreferenceProfile(
             ballots=tuple([b for b in transfered_ballots if b.ranking and b.weight > 0])
         )
-        .condense_ballots()
+        .group_ballots()
         .ballots
     )
 
@@ -130,6 +130,6 @@ def random_transfer(
         PreferenceProfile(
             ballots=tuple([b for b in updated_ballots if b.ranking and b.weight > 0])
         )
-        .condense_ballots()
+        .group_ballots()
         .ballots
     )

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -362,7 +362,7 @@ class PreferenceProfile:
     # set repr to print outputs
     __repr__ = __str__
 
-    def condense_ballots(self) -> PreferenceProfile:
+    def group_ballots(self) -> PreferenceProfile:
         """
         Groups ballots by rankings and scores and updates weights. Retains voter sets, but
         loses ballot ids.
@@ -417,8 +417,8 @@ class PreferenceProfile:
     def __eq__(self, other):
         if not isinstance(other, PreferenceProfile):
             return False
-        pp_1 = self.condense_ballots()
-        pp_2 = other.condense_ballots()
+        pp_1 = self.group_ballots()
+        pp_2 = other.group_ballots()
         for b in pp_1.ballots:
             if b not in pp_2.ballots:
                 return False
@@ -453,7 +453,7 @@ class PreferenceProfile:
         if isinstance(other, PreferenceProfile):
             ballots = self.ballots + other.ballots
             pp = PreferenceProfile(ballots=ballots)
-            pp.condense_ballots()
+            pp.group_ballots()
             return pp
         else:
             raise TypeError(

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -368,7 +368,7 @@ class PreferenceProfile:
         loses ballot ids.
 
         Returns:
-            PreferenceProfile: A PreferenceProfile object with condensed ballot list.
+            PreferenceProfile: A PreferenceProfile object with grouped ballot list.
         """
 
         seen_ballots = {}
@@ -381,18 +381,14 @@ class PreferenceProfile:
             if weightless_ballot not in seen_ballots:
                 seen_ballots[weightless_ballot] = {
                     "weight": ballot.weight,
-                    "voter_set": ballot.voter_set if ballot.voter_set else set(),
+                    "voter_set": ballot.voter_set,
                 }
 
             else:
                 seen_ballots[weightless_ballot]["weight"] += ballot.weight  # type: ignore[operator]
-
-                if ballot.voter_set:
-                    seen_ballots[weightless_ballot][
-                        "voter_set"
-                    ].update(  # type: ignore[attr-defined]
-                        ballot.voter_set
-                    )
+                seen_ballots[weightless_ballot]["voter_set"].update(
+                    ballot.voter_set
+                )  # type: ignore[attr-defined]
 
         new_ballots = [Ballot()] * len(seen_ballots)
 
@@ -401,11 +397,7 @@ class PreferenceProfile:
                 ranking=ballot.ranking,
                 scores=ballot.scores,
                 weight=ballot_dict["weight"],  # type: ignore[arg-type]
-                voter_set=(
-                    ballot_dict["voter_set"]  # type: ignore[arg-type]
-                    if len(ballot_dict["voter_set"])  # type: ignore[arg-type]
-                    else None
-                ),
+                voter_set=ballot_dict["voter_set"],  # type: ignore[arg-type]
             )
 
         return PreferenceProfile(

--- a/src/votekit/pref_profile.py
+++ b/src/votekit/pref_profile.py
@@ -364,41 +364,55 @@ class PreferenceProfile:
 
     def condense_ballots(self) -> PreferenceProfile:
         """
-        Groups ballots by rankings and scores and updates weights.
+        Groups ballots by rankings and scores and updates weights. Retains voter sets, but
+        loses ballot ids.
 
         Returns:
             PreferenceProfile: A PreferenceProfile object with condensed ballot list.
         """
-        weight_accumulator = {}
 
-        # weightless allows for id of ballots with matching ranking/scores
+        seen_ballots = {}
+
         for ballot in self.ballots:
-            weightless_ballot = (
-                Ballot(ranking=ballot.ranking, weight=Fraction(0), scores=ballot.scores)
-                if ballot.scores
-                else Ballot(ranking=ballot.ranking, weight=Fraction(0))
+            weightless_ballot = Ballot(
+                ranking=ballot.ranking, scores=ballot.scores, weight=Fraction(0)
             )
-            if weightless_ballot not in weight_accumulator:
-                weight_accumulator[weightless_ballot] = Fraction(0)
 
-            weight_accumulator[weightless_ballot] += ballot.weight
+            if weightless_ballot not in seen_ballots:
+                seen_ballots[weightless_ballot] = {
+                    "weight": ballot.weight,
+                    "voter_set": ballot.voter_set if ballot.voter_set else set(),
+                }
 
-        new_ballot_list = [Ballot()] * len(weight_accumulator)
-        i = 0
-        for ballot, weight in weight_accumulator.items():
-            if ballot.scores:
-                new_ballot_list[i] = Ballot(
-                    ranking=ballot.ranking, scores=ballot.scores, weight=weight
-                )
             else:
-                new_ballot_list[i] = Ballot(ranking=ballot.ranking, weight=weight)
+                seen_ballots[weightless_ballot]["weight"] += ballot.weight  # type: ignore[operator]
 
-            i += 1
+                if ballot.voter_set:
+                    seen_ballots[weightless_ballot][
+                        "voter_set"
+                    ].update(  # type: ignore[attr-defined]
+                        ballot.voter_set
+                    )
 
-        condensed_profile = PreferenceProfile(
-            ballots=tuple(new_ballot_list), candidates=self.candidates
+        new_ballots = [Ballot()] * len(seen_ballots)
+
+        for i, (ballot, ballot_dict) in enumerate(seen_ballots.items()):
+            new_ballots[i] = Ballot(
+                ranking=ballot.ranking,
+                scores=ballot.scores,
+                weight=ballot_dict["weight"],  # type: ignore[arg-type]
+                voter_set=(
+                    ballot_dict["voter_set"]  # type: ignore[arg-type]
+                    if len(ballot_dict["voter_set"])  # type: ignore[arg-type]
+                    else None
+                ),
+            )
+
+        return PreferenceProfile(
+            ballots=tuple(new_ballots),
+            candidates=self.candidates,
+            max_ballot_length=self.max_ballot_length,
         )
-        return condensed_profile
 
     def __eq__(self, other):
         if not isinstance(other, PreferenceProfile):

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -167,7 +167,7 @@ def remove_cand(
             )
 
         if condense:
-            clean_profile = clean_profile.condense_ballots()
+            clean_profile = clean_profile.group_ballots()
 
         return cast(COB, clean_profile)
 
@@ -184,7 +184,7 @@ def remove_cand(
             )
 
         if condense:
-            clean_profile = clean_profile.condense_ballots()
+            clean_profile = clean_profile.group_ballots()
 
         return cast(COB, clean_profile.ballots[0])
     else:
@@ -200,7 +200,7 @@ def remove_cand(
             )
 
         if condense:
-            clean_profile = clean_profile.condense_ballots()
+            clean_profile = clean_profile.group_ballots()
 
         return cast(COB, clean_profile.ballots)
 
@@ -242,7 +242,7 @@ def add_missing_cands(profile: PreferenceProfile) -> PreferenceProfile:
 
     return PreferenceProfile(
         ballots=tuple(new_ballots), candidates=tuple(candidates)
-    ).condense_ballots()
+    ).group_ballots()
 
 
 def validate_score_vector(score_vector: Sequence[Union[float, Fraction]]):
@@ -695,7 +695,7 @@ def resolve_profile_ties(profile: PreferenceProfile) -> PreferenceProfile:
     new_ballots = tuple(
         [b for ballot in profile.ballots for b in expand_tied_ballot(ballot)]
     )
-    return PreferenceProfile(ballots=new_ballots).condense_ballots()
+    return PreferenceProfile(ballots=new_ballots).group_ballots()
 
 
 def score_profile_from_ballot_scores(

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -135,19 +135,35 @@ def remove_cand(
 
         if len(new_ranking) > 0 and len(new_scores) > 0:
             scrubbed_ballots[i] = Ballot(
-                ranking=tuple(new_ranking), weight=ballot.weight, scores=new_scores
+                ranking=tuple(new_ranking),
+                weight=ballot.weight,
+                scores=new_scores,
+                voter_set=ballot.voter_set,
+                id=ballot.id,
             )
         elif len(new_ranking) > 0:
             scrubbed_ballots[i] = Ballot(
-                ranking=tuple(new_ranking), weight=ballot.weight
+                ranking=tuple(new_ranking),
+                weight=ballot.weight,
+                voter_set=ballot.voter_set,
+                id=ballot.id,
             )
 
         elif len(new_scores) > 0:
-            scrubbed_ballots[i] = Ballot(weight=ballot.weight, scores=new_scores)
+            scrubbed_ballots[i] = Ballot(
+                weight=ballot.weight,
+                scores=new_scores,
+                voter_set=ballot.voter_set,
+                id=ballot.id,
+            )
 
         # else ballot exhausted
         else:
-            scrubbed_ballots[i] = Ballot(weight=Fraction(0))
+            scrubbed_ballots[i] = Ballot(
+                weight=Fraction(0),
+                voter_set=ballot.voter_set,
+                id=ballot.id,
+            )
 
     # return matching input data type
     if isinstance(profile_or_ballots, PreferenceProfile):

--- a/tests/test_pref_profile.py
+++ b/tests/test_pref_profile.py
@@ -194,13 +194,24 @@ def test_to_scores_dict():
 def test_condense_profile_ranking():
     profile = PreferenceProfile(
         ballots=(
-            Ballot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(1)),
             Ballot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(2)),
+            Ballot(
+                ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(1), voter_set={"Chris"}
+            ),
+            Ballot(
+                ranking=({"A"}, {"B"}, {"C"}),
+                weight=Fraction(2),
+                voter_set={"Moon", "Peter"},
+            ),
         ),
         candidates=("A", "B", "C", "D"),
     )
     pp = profile.condense_ballots()
-    assert pp.ballots[0] == Ballot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(3))
+    assert pp.ballots[0] == Ballot(
+        ranking=({"A"}, {"B"}, {"C"}),
+        weight=Fraction(5),
+        voter_set={"Chris", "Moon", "Peter"},
+    )
     assert set(pp.candidates) == set(profile.candidates)
 
 
@@ -211,19 +222,37 @@ def test_condense_profile_scores():
                 ranking=({"A"}, {"B"}, {"C"}),
                 scores={"A": 3, "B": 2},
                 weight=Fraction(1),
+                voter_set={"Chris"},
             ),
             Ballot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(2)),
             Ballot(
                 ranking=({"A"}, {"B"}, {"C"}),
                 scores={"A": 3, "B": 2},
                 weight=Fraction(2),
+                voter_set={"Peter", "Moon"},
             ),
         )
     )
     pp = profile.condense_ballots()
-    assert pp.ballots[0] == Ballot(
-        ranking=({"A"}, {"B"}, {"C"}), scores={"A": 3, "B": 2}, weight=Fraction(3)
+
+    for b in pp.ballots:
+        print(b.ranking)
+        print(b.scores)
+        print(b.voter_set)
+        print(b.weight)
+        print()
+
+    assert (
+        Ballot(
+            ranking=({"A"}, {"B"}, {"C"}),
+            scores={"A": 3, "B": 2},
+            weight=Fraction(3),
+            voter_set={"Chris", "Moon", "Peter"},
+        )
+        in pp.ballots
     )
+
+    assert Ballot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(2)) in pp.ballots
 
 
 def test_profile_equals():

--- a/tests/test_pref_profile.py
+++ b/tests/test_pref_profile.py
@@ -206,7 +206,7 @@ def test_condense_profile_ranking():
         ),
         candidates=("A", "B", "C", "D"),
     )
-    pp = profile.condense_ballots()
+    pp = profile.group_ballots()
     assert pp.ballots[0] == Ballot(
         ranking=({"A"}, {"B"}, {"C"}),
         weight=Fraction(5),
@@ -233,7 +233,7 @@ def test_condense_profile_scores():
             ),
         )
     )
-    pp = profile.condense_ballots()
+    pp = profile.group_ballots()
 
     for b in pp.ballots:
         print(b.ranking)


### PR DESCRIPTION
- Update the condense_ballots() method of PreferenceProfile to also include the voter_set attribute.
- Rename condense_ballots to group_ballots to avoid confusion with new terminology of condense ballot introduced in Portland report. (That now refers to removing empty ranking positions and moving lower candidates up ballot).
- Update other functions in code base to include voter_set and id attribute