### PR TITLE
3.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: ruff
   - repo: https://github.com/ambv/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   # - repo: https://github.com/pre-commit/mirrors-mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2025-06-17
+## Added
+
+## Changed 
+- removed the `PreferenceProfile` warning raised when `max_ranking_length>0` but no rankings provided.
+We have decided an empty profile can still have positive max ranking length.
+
+## Fixed
+- fixed an error raised by an empty ranking of `~` symbols being passed to `utils.ballots_by_first_cand` .
+
 ## [3.2.0] - 2025-06-13
 ## Added
 - created a `PreferenceProfile.df` attribute that is a pandas `DataFrame` representation of the profile. The df is in bijection with the profile, and using the df allows for great speed improvements throughout the codebase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "votekit"
-version = "3.2.0"
+version = "3.2.1"
 description = "A Swiss army knife for computational social choice research."
 authors = [{name = "MGGG", email =  "code@mggg.org"}]
 readme = "README.md"

--- a/src/votekit/matrices/heatmap.py
+++ b/src/votekit/matrices/heatmap.py
@@ -132,7 +132,7 @@ def _add_text_to_heatmap(
 
             # Normalize the cell value between 0 and 1, then get the RGBA color
             norm_val = quadmesh.norm(val)
-            r, g, b, _ = quadmesh.cmap(norm_val)
+            r, g, b, _ = quadmesh.cmap(norm_val)  # type: ignore[misc]
 
             # Simple brightness measure: average of R, G, B
             brightness = (r + g + b) / 3

--- a/src/votekit/pref_profile/pref_profile.py
+++ b/src/votekit/pref_profile/pref_profile.py
@@ -650,10 +650,6 @@ class PreferenceProfile:
         ProfileError: candidates must be unique.
         ProfileError: candidates must not have names matching ranking columns.
 
-    Warns:
-        UserWarning: max_ranking_length is set but contains_rankings is False.
-            Sets max_ranking_length to 0.
-
     """
 
     _is_frozen: bool = False
@@ -1101,20 +1097,8 @@ class PreferenceProfile:
         Returns:
             int: Max ranking length.
 
-        Warns:
-            UserWarning: If a max_ranking_length is provided but not rankings are in the
-                profile, we set the max_ranking_length to 0.
         """
-        if self.max_ranking_length > 0 and self.contains_rankings is False:
-            warnings.warn(
-                "Profile does not contain rankings but "
-                f"max_ranking_length={self.max_ranking_length}. Setting max_ranking_length"
-                " to 0."
-            )
-
-            return 0
-
-        elif self.max_ranking_length == 0 and self.contains_rankings is True:
+        if self.max_ranking_length == 0 and self.contains_rankings is True:
             return len([c for c in self.df.columns if "Ranking_" in c])
 
         return self.max_ranking_length

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -87,6 +87,9 @@ def ballots_by_first_cand(profile: PreferenceProfile) -> dict[str, list[Ballot]]
 
         cand = next(iter(first))
 
+        if cand == "~":
+            continue
+
         clean_ranking = tuple(s for s in row if s != tilde)
 
         cand_dict[cand].append(Ballot(ranking=clean_ranking, weight=w))

--- a/tests/elections/election_types/ranking/test_irv.py
+++ b/tests/elections/election_types/ranking/test_irv.py
@@ -85,7 +85,7 @@ profile_list = [
         ],
         max_ranking_length=3,
     ),
-    PreferenceProfile(max_ranking_length=3),
+    PreferenceProfile(),
 ]
 
 states = [

--- a/tests/pref_profile/test_pp_ranking_length.py
+++ b/tests/pref_profile/test_pp_ranking_length.py
@@ -1,6 +1,5 @@
 from votekit.ballot import Ballot
 from votekit.pref_profile import PreferenceProfile
-import pytest
 
 
 def test_ranking_length_default():
@@ -14,29 +13,6 @@ def test_ranking_length_default():
     )
 
     assert profile.max_ranking_length == 3
-
-
-def test_ranking_length_warning():
-
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "Profile does not contain rankings but "
-            "max_ranking_length=3. Setting max_ranking_length"
-            " to 0."
-        ),
-    ):
-        profile_scores = PreferenceProfile(
-            ballots=(
-                Ballot(
-                    scores={"A": 2, "B": 4, "D": 1},
-                ),
-            ),
-            candidates=["A", "B", "C", "D", "E"],
-            max_ranking_length=3,
-        )
-
-    assert profile_scores.max_ranking_length == 0
 
 
 def test_ranking_length_no_default():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,7 +47,15 @@ profile_with_missing = PreferenceProfile(
 
 
 def test_ballots_by_first_cand():
-    cand_dict = ballots_by_first_cand(profile_no_ties)
+    profile = PreferenceProfile(
+        ballots=[
+            Ballot(ranking=[{"A"}, {"B"}], weight=1),
+            Ballot(ranking=[{"A"}, {"B"}, {"C"}], weight=1 / 2),
+            Ballot(ranking=[{"C"}, {"B"}, {"A"}], weight=3),
+            Ballot(scores={"C": 1}),
+        ]
+    )
+    cand_dict = ballots_by_first_cand(profile)
     partition = {
         "A": [
             Ballot(ranking=[{"A"}, {"B"}], weight=1),


### PR DESCRIPTION
This patch for #216 includes:

- removed the `PreferenceProfile` warning raised when `max_ranking_length>0` but no rankings provided.
We have decided an empty profile can still have positive max ranking length.
- fixed an error raised by an empty ranking of `~` symbols being passed to `utils.ballots_by_first_cand` .

This updates the version number and changelog.