### PR TITLE
patch stv bug

### DIFF
--- a/src/votekit/elections/election_types/ranking/stv.py
+++ b/src/votekit/elections/election_types/ranking/stv.py
@@ -184,7 +184,7 @@ class STV(RankingElection):
             if b.ranking
         )
 
-        remaining_cands = set(profile.candidates).difference(
+        remaining_cands = set(profile.candidates_cast).difference(
             [c for s in elected for c in s]
         )
 
@@ -257,7 +257,7 @@ class STV(RankingElection):
             if b.ranking
         )
 
-        remaining_cands = set(profile.candidates).difference(
+        remaining_cands = set(profile.candidates_cast).difference(
             [c for s in elected for c in s]
         )
         new_profile = PreferenceProfile(
@@ -311,7 +311,7 @@ class STV(RankingElection):
         # catches the possibility that we exhaust all ballots
         # without candidates reaching threshold
 
-        elif len(profile.candidates) == self.m - len(
+        elif len(profile.candidates_cast) == self.m - len(
             [c for s in self.get_elected() for c in s]
         ):
             elected = prev_state.remaining

--- a/tests/elections/election_types/ranking/test_stv.py
+++ b/tests/elections/election_types/ranking/test_stv.py
@@ -344,3 +344,16 @@ def test_errors():
 
     with pytest.raises(TypeError, match="Ballots must have rankings."):
         STV(PreferenceProfile(ballots=(Ballot(scores={"A": 4}),)))
+
+
+def test_stv_cands_cast():
+    profile = PreferenceProfile(
+        ballots=(
+            Ballot(ranking=({"A"},), weight=4),
+            Ballot(ranking=({"B"},), weight=2),
+            Ballot(ranking=({"C"},), weight=5),
+        ),
+        candidates=["A", "B", "C", "D", "E"],
+    )
+
+    assert STV(profile, m=3).get_elected() == ({"C"}, {"A"}, {"B"})


### PR DESCRIPTION
STV was raising an index error when provided with profiles that had short ballots. The underlying issue was STV accessing the list of candidates, rather than `candidates_cast`. Now it only uses candidates that receive non-zero votes to compute "remaining" candidates.