### PR TITLE
README: adjust ruff commmands and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ minn_election.run_election()
 ## Issues and Contributing
 This project is in active development in the [mggg/VoteKit](https://github.com/mggg/VoteKit) GitHub repository, where [bug reports and feature requests](https://votekit.readthedocs.io/en/latest/package_info/issues/), as well as [contributions](https://votekit.readthedocs.io/en/latest/package_info/contributing/), are welcome.
 
-Currently VoteKit uses `poetry` to manage the development environment. If you want to make a pull request, first `pip install poetry` to your computer. Then, within the Votekit directory and with a virtual environment activated, run `poetry install .` This will install all of the development packages you might need. Before making a pull request, run the following:
+Currently VoteKit uses `poetry` to manage the development environment. If you want to make a pull request, first `pip install poetry` to your computer. Then, within the Votekit directory and with a virtual environment activated, run `poetry install` This will install all of the development packages you might need. Before making a pull request, run the following:
 - `poetry run pytest tests` to check the test suite,
 - `poetry run black .` to format your code,
 - `poetry run ruff check .` to check the formatting, and then

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ minn_election.run_election()
 ## Issues and Contributing
 This project is in active development in the [mggg/VoteKit](https://github.com/mggg/VoteKit) GitHub repository, where [bug reports and feature requests](https://votekit.readthedocs.io/en/latest/package_info/issues/), as well as [contributions](https://votekit.readthedocs.io/en/latest/package_info/contributing/), are welcome.
 
-Currently VoteKit uses `poetry` to manage the development environment. If you want to make a pull request, first `pip install poetry` to your computer. Then, within the VOTEkit directory and with a virtual environment activated, run `poetry install .` This will install all of the development packages you might need. Before making a pull request, run the following:
+Currently VoteKit uses `poetry` to manage the development environment. If you want to make a pull request, first `pip install poetry` to your computer. Then, within the Votekit directory and with a virtual environment activated, run `poetry install .` This will install all of the development packages you might need. Before making a pull request, run the following:
 - `poetry run pytest tests` to check the test suite,
 - `poetry run black .` to format your code,
-- `poetry run ruff .` to check the formatting, and then
+- `poetry run ruff check .` to check the formatting, and then
 - `poetry run mypy src` to ensure that your typesetting is correct.
 
 Then you can create your PR! Please do not make your PR against `main`.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This project is in active development in the [mggg/VoteKit](https://github.com/m
 Currently VoteKit uses `poetry` to manage the development environment. If you want to make a pull request, first `pip install poetry` to your computer. Then, within the Votekit directory and with a virtual environment activated, run `poetry install` This will install all of the development packages you might need. Before making a pull request, run the following:
 - `poetry run pytest tests` to check the test suite,
 - `poetry run black .` to format your code,
-- `poetry run ruff check .` to check the formatting, and then
+- `poetry run ruff check src tests` to check the formatting, and then
 - `poetry run mypy src` to ensure that your typesetting is correct.
 
 Then you can create your PR! Please do not make your PR against `main`.


### PR DESCRIPTION
Currently the README instructs `poetry run ruff .` to execute the `ruff` check. However, on my machine I instead needed to run `poetry run ruff check .` in order for `ruff` to execute. I think other's have had a similar  issue, but let me know `poetry run ruff .` works on y'all's system and i can can update this change to include both.
I also corrected the README typo that was included as part of the "contributing to open source" tutorial from a while ago