### PR TITLE
Fix #258. 

### DIFF
--- a/src/votekit/elections/election_state.py
+++ b/src/votekit/elections/election_state.py
@@ -33,3 +33,19 @@ class ElectionState:
         default_factory=dict
     )
     scores: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Convert the ElectionState to a dictionary representation.
+        """
+        return {
+            "round_number": self.round_number,
+            "remaining": tuple(map(tuple, self.remaining)),
+            "elected": tuple(map(tuple, self.elected)),
+            "eliminated": tuple(map(tuple, self.eliminated)),
+            "tiebreaks": {
+                tuple(tie): tuple(map(tuple, resolution))
+                for tie, resolution in self.tiebreaks.items()
+            },
+            "scores": self.scores,
+        }

--- a/src/votekit/elections/election_types/ranking/stv.py
+++ b/src/votekit/elections/election_types/ranking/stv.py
@@ -291,6 +291,7 @@ class STV(RankingElection):
         """
         tiebreaks: dict[frozenset[str], tuple[frozenset[str], ...]] = {}
 
+        current_round = prev_state.round_number + 1
         above_thresh_cands = [
             c for c, score in prev_state.scores.items() if score >= self.threshold
         ]
@@ -322,12 +323,21 @@ class STV(RankingElection):
             lowest_fpv_cands = prev_state.remaining[-1]
 
             if len(lowest_fpv_cands) > 1:
-                tiebroken_ranking = tiebreak_set(
-                    lowest_fpv_cands, self.get_profile(0), tiebreak="first_place"
-                )
+                tiebroken_ranking = None
+                if current_round < len(self.election_states):
+                    possible_tiebreaks = list(
+                        self.election_states[current_round].tiebreaks.values()
+                    )
+                    if len(possible_tiebreaks) > 0:
+                        tiebroken_ranking = possible_tiebreaks[0]
+                if tiebroken_ranking is None or len(tiebroken_ranking) == 0:
+                    tiebroken_ranking = tiebreak_set(
+                        lowest_fpv_cands, self.get_profile(0), tiebreak="first_place"
+                    )
+
                 tiebreaks = {lowest_fpv_cands: tiebroken_ranking}
 
-                eliminated_cand = list(tiebroken_ranking[-1])[0]
+                eliminated_cand = list(tiebroken_ranking[-1])[-1]
 
             else:
                 eliminated_cand = list(lowest_fpv_cands)[0]

--- a/tests/elections/election_types/ranking/test_stv.py
+++ b/tests/elections/election_types/ranking/test_stv.py
@@ -357,3 +357,25 @@ def test_stv_cands_cast():
     )
 
     assert STV(profile, m=3).get_elected() == ({"C"}, {"A"}, {"B"})
+
+
+def test_stv_resolves_tiebreaks_consistently_on_rerun():
+    for _ in range(100):
+        profile = PreferenceProfile(
+            ballots=(
+                Ballot(ranking=({"Orange"}, {"Pear"}), weight=5),
+                Ballot(ranking=({"Pear"}, {"Strawberry"}, {"Cake"}), weight=8),
+                Ballot(ranking=({"Strawberry"}, {"Orange"}, {"Pear"}), weight=1),
+                Ballot(ranking=({"Cake"}, {"Chocolate"}), weight=3),
+                Ballot(ranking=({"Chocolate"}, {"Cake"}, {"Burger"}), weight=2),
+                Ballot(ranking=({"Burger"}, {"Chicken"}), weight=4),
+                Ballot(ranking=({"Chicken"}, {"Chocolate"}, {"Burger"}), weight=4),
+            ),
+            max_ranking_length=3,
+        )
+
+        # There is a tiebreak between Burger and Chicken that must be resolved
+        election = STV(profile, m=3)
+
+        # The following line will error if the tiebreaks are not resolved consistently
+        election.get_step(7)


### PR DESCRIPTION
Issue was that we re-resolved random tiebreaks on rerun of the election (when we call `_run_step`)