### PR TITLE
Change error message for negative ballot weight

### DIFF
--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -36,7 +36,7 @@ class Ballot:
 
     def __post_init__(self):
         if self.weight < 0:
-            raise ValueError("Ballot weight must cannot be negative.")
+            raise ValueError("Ballot weight cannot be negative.")
 
         # Silently promote weight to float
         object.__setattr__(self, "weight", float(self.weight))

--- a/tests/test_ballot.py
+++ b/tests/test_ballot.py
@@ -96,3 +96,8 @@ def test_ballot_tilde_errors():
         match="'~' is a reserved character and cannot be used for candidate names.",
     ):
         Ballot(scores={"~": 1})
+
+
+def test_ballot_negative_weight():
+    with pytest.raises(ValueError, match="Ballot weight cannot be negative."):
+        Ballot(weight=-1.5)


### PR DESCRIPTION
The error message for negative ballot weights had a grammatical error; there was also no test to make sure that error was raised.