### PR TITLE
Bugfix: max candidates ranked > max_ranking_length

### DIFF
--- a/src/votekit/pref_profile/pref_profile.py
+++ b/src/votekit/pref_profile/pref_profile.py
@@ -614,13 +614,11 @@ class RankProfile(PreferenceProfile):
     @cached_property
     def max_candidates_ranked(self) -> int:
         """
-        Computes the maximum number of candidates ranked on any ballot in the profile. Can be
-        longer than max_ranking_length if a ballot has ties. E.g., a ballot that ranks two
-        candidates tied for first and ranks no other candidates has length 1, but ranks 2
-        candidates in total.
+        The maximum number of candidates ranked on any ballot in the profile.
 
-        Returns:
-            int: Maximum number of candidates ranked.
+        Can be longer than max_ranking_length if a ballot has ties.
+        E.g., a ballot that ranks two candidates tied for first and ranks no other candidates
+        has length 1, but ranks 2 candidates in total.
         """
         if self.df.empty:
             return 0

--- a/src/votekit/pref_profile/pref_profile.py
+++ b/src/votekit/pref_profile/pref_profile.py
@@ -312,6 +312,18 @@ class RankProfile(PreferenceProfile):
 
         self.max_ranking_length = self._find_max_ranking_length()
 
+        if self.max_ranking_length > 0:
+            if self.max_candidates_ranked > self.max_ranking_length:
+                msg = (
+                    "This preference profile contains ballot(s) whose number of candidates "
+                    "exceeds the length of the longest ranking. "
+                    "It's likely that you need to clean the profile to remove ties. "
+                    "If the profile is exactly as you expect, "
+                    f"pass max_ranking_length={self.max_candidates_ranked} "
+                    "to RankProfile()."
+                )
+                raise ValueError(msg)
+
         super().__init__(
             candidates=self.candidates,
             candidates_cast=self.candidates_cast,
@@ -598,6 +610,28 @@ class RankProfile(PreferenceProfile):
             return len([c for c in self.df.columns if "Ranking_" in c])
 
         return self.max_ranking_length
+
+    @cached_property
+    def max_candidates_ranked(self) -> int:
+        """
+        Computes the maximum number of candidates ranked on any ballot in the profile. Can be
+        longer than max_ranking_length if a ballot has ties. E.g., a ballot that ranks two
+        candidates tied for first and ranks no other candidates has length 1, but ranks 2
+        candidates in total.
+
+        Returns:
+            int: Maximum number of candidates ranked.
+        """
+        if self.df.empty:
+            return 0
+        tilde = frozenset("~")
+        assert self.max_ranking_length is not None
+        ranking_cols = [f"Ranking_{i}" for i in range(1, self.max_ranking_length + 1)]
+        return (
+            self.df[ranking_cols]
+            .apply(lambda row: len(frozenset.union(*row) - tilde), axis=1)
+            .max()
+        )
 
     @cached_property
     def ballots(self: RankProfile) -> tuple[RankBallot, ...]:

--- a/tests/elections/election_types/ranking/test_boosted_random_dictator.py
+++ b/tests/elections/election_types/ranking/test_boosted_random_dictator.py
@@ -138,7 +138,9 @@ def test_boosted_random_dictator_4_candidates_with_ties():
         map(lambda x: Ballot(ranking=[x], weight=3 if "A" in x[0] else 1), powerset)
     )
 
-    test_profile = PreferenceProfile(ballots=ballots, candidates=candidates)
+    test_profile = PreferenceProfile(
+        ballots=ballots, candidates=candidates, max_ranking_length=4
+    )
 
     trials = 4000
 

--- a/tests/elections/election_types/ranking/test_random_dictator.py
+++ b/tests/elections/election_types/ranking/test_random_dictator.py
@@ -117,7 +117,9 @@ def test_random_dictator_4_candidates_with_ties():
         map(lambda x: Ballot(ranking=[x], weight=3 if "A" in x[0] else 1), powerset)
     )
 
-    test_profile = PreferenceProfile(ballots=ballots, candidates=candidates)
+    test_profile = PreferenceProfile(
+        ballots=ballots, candidates=candidates, max_ranking_length=4
+    )
 
     trials = 750
 

--- a/tests/pref_profile/rank_profile/test_rank_pp_ranking_length.py
+++ b/tests/pref_profile/rank_profile/test_rank_pp_ranking_length.py
@@ -1,17 +1,21 @@
+import pytest
+
 from votekit.ballot import RankBallot
 from votekit.pref_profile import RankProfile
 
 
 def test_ranking_length_default():
-    profile = RankProfile(
-        ballots=(
-            RankBallot(ranking=({"A"}, {"B"}, {"C", "D"})),
-            RankBallot(ranking=({"A"}, {"B"}), weight=3 / 2),
-            RankBallot(ranking=({"C"}, {"B"}), weight=2),
+    with pytest.raises(
+        ValueError,
+        match="number of candidates exceeds the length of the longest ranking",
+    ):
+        RankProfile(
+            ballots=(
+                RankBallot(ranking=({"A"}, {"B"}, {"C", "D"})),
+                RankBallot(ranking=({"A"}, {"B"}), weight=3 / 2),
+                RankBallot(ranking=({"C"}, {"B"}), weight=2),
+            )
         )
-    )
-
-    assert profile.max_ranking_length == 3
 
 
 def test_ranking_length_no_default():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-from votekit.ballot import Ballot
-from votekit.pref_profile import PreferenceProfile
+from votekit.ballot import Ballot, RankBallot
+from votekit.pref_profile import PreferenceProfile, RankProfile
 from votekit.utils import (
     ballots_by_first_cand,
     add_missing_cands,
@@ -44,6 +44,29 @@ profile_with_missing = PreferenceProfile(
     ),
     candidates=("A", "B", "C", "D", "E"),
 )
+
+
+class TestShortBallot:
+    # this profile has max_ranking_length = 1 but max_candidates_ranked = 2
+    # A and B are tied for first on the sole ballot
+    def test_illegal_short_profile(self):
+        with pytest.raises(
+            ValueError,
+            match="number of candidates exceeds the length of the longest ranking.",
+        ):
+            _ = RankProfile(ballots=(RankBallot(ranking=("AB",), weight=5),))
+
+    def test_legal_short_profile(self):
+        profile = RankProfile(
+            ballots=(
+                RankBallot(
+                    ranking=("AB",),
+                    weight=5,
+                ),
+            ),
+            max_ranking_length=2,
+        )
+        assert profile.max_candidates_ranked == profile.max_ranking_length
 
 
 def test_ballots_by_first_cand():


### PR DESCRIPTION
If a RankProfile contains a ballot that ranks more than max_ranking_length candidates, some of the scoring functions can either crash or silently return incorrect results.

For example, consider a profile with a single ballot that ranks candidates A and B as tied for first. first_place_votes(profile, scoring_tie_convention='low') should return 0 for each candidate, but it instead returns 1. The score functions create a score_vector whose length is max_ranking_length, so, in this case, the score_vector is just [1], and when we have two candidates tied for first, taking min([1]) gives both 1. The correct behavior should be: the score_vector is [1, 0], so min yields 0.

To fix this, we should consider such profiles to be malformed, and insist that the user explicitly pass max_ranking_length.

The implementation: RankProfile now has a cached_property max_candidates_ranked, which, at initialization, is computed and compared against max_ranking_length. If max_candidates_ranked > max_ranking_length, RankProfile throws an error and suggests that the user either clean the profile to remove ties or explicitly pass max_ranking_length equal to whatever it computed max_candidates_ranked to be.

I updated the following tests:
1. utils - added a check that this error is raised
2. random dictator and boosted random dictator - these created profiles that are now considered malformed, so I added explicit passing of max_ranking_length.
3. test_rank_pp_ranking_length - this created a malformed profile (4 candidates ranked, but max_ranking_length implicitly equal to 3) and insisted that the result was a profile whose max_ranking_length is 3. I changed this to be a check for the error (same as utils essentially)