### PR TITLE
Faster mentions

### DIFF
--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -1,9 +1,8 @@
 import math
 import random
-from fractions import Fraction
 from itertools import permutations
 from typing import Literal, Optional, Sequence, Union
-
+from typing import Any, cast
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
@@ -384,17 +383,7 @@ def _ballots_are_materialized(profile: RankProfile) -> bool:
     return "ballots" in profile.__dict__
 
 
-def _mentions_from_df(profile: RankProfile) -> dict[str, Fraction]:
-    """
-    Faster pandas-based mentions calculator for RankProfiles where ballots are not materialized.
-
-    Args:
-        profile (RankProfile): RankProfile of ballots.
-
-    Returns:
-        dict[str, float]:
-            Dictionary mapping candidates to mention totals (values).
-    """
+def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     assert profile.max_ranking_length is not None
 
     ranking_cols = [
@@ -404,32 +393,40 @@ def _mentions_from_df(profile: RankProfile) -> dict[str, Fraction]:
 
     tilde = frozenset({"~"})
 
-    rank_sets = profile.df[ranking_cols].stack()
+    rank_sets = cast(
+        pd.Series[Any],
+        profile.df[ranking_cols].stack(),
+    )
 
-    rank_sets = rank_sets[
+    mask = cast(
+        pd.Series[Any],
         rank_sets.map(
             lambda s: isinstance(s, frozenset) and bool(s) and s != tilde
-        )
-    ]
+        ),
+    )
+
+    rank_sets = rank_sets[mask]
 
     exploded = rank_sets.explode()
 
     if exploded.empty:
-        return {c: Fraction(0) for c in profile.candidates}
+        return {c: 0.0 for c in profile.candidates}
 
-    weights = profile.df["Weight"].reindex(
-        exploded.index.get_level_values(0)
-    ).to_numpy()
+    weights = (
+        profile.df["Weight"]
+        .reindex(exploded.index.get_level_values(0))
+        .to_numpy()
+    )
 
     totals = pd.Series(weights).groupby(exploded.to_numpy(), sort=False).sum()
 
     return {
-        c: totals.get(c, Fraction(0))
+        c: totals.get(c, 0.0)
         for c in profile.candidates
     }
 
 
-def fast_mentions(profile: RankProfile) -> dict[str, Fraction]:
+def fast_mentions(profile: RankProfile) -> dict[str, float]:
     """
     Decides which way to compute mentions based on whether ballots are materialized in the profile. 
     If they are, uses the traditional mentions calculation. 

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -386,18 +386,13 @@ def _ballots_are_materialized(profile: RankProfile) -> bool:
 def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     assert profile.max_ranking_length is not None
 
-    ranking_cols = [
-        f"Ranking_{i}"
-        for i in range(1, profile.max_ranking_length + 1)
-    ]
+    ranking_cols = [f"Ranking_{i}" for i in range(1, profile.max_ranking_length + 1)]
 
     tilde = frozenset({"~"})
 
     rank_sets = cast(Any, profile.df[ranking_cols].stack())
 
-    mask = rank_sets.map(
-            lambda s: isinstance(s, frozenset) and bool(s) and s != tilde
-        )
+    mask = rank_sets.map(lambda s: isinstance(s, frozenset) and bool(s) and s != tilde)
 
     rank_sets = rank_sets[mask]
     exploded = rank_sets.explode()
@@ -405,18 +400,12 @@ def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     if exploded.empty:
         return {c: 0.0 for c in profile.candidates}
 
-    weights = (
-        profile.df["Weight"]
-        .reindex(exploded.index.get_level_values(0))
-        .to_numpy()
-    )
+    weights = profile.df["Weight"].reindex(exploded.index.get_level_values(0)).to_numpy()
 
     totals = pd.Series(weights).groupby(exploded.to_numpy(), sort=False).sum()
 
-    return {
-        c: totals.get(c, 0.0)
-        for c in profile.candidates
-    }
+    return {c: totals.get(c, 0.0) for c in profile.candidates}
+
 
 def fast_mentions(profile: RankProfile) -> dict[str, float]:
     """

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -1,5 +1,6 @@
 import math
 import random
+from fractions import Fraction
 from itertools import permutations
 from typing import Literal, Optional, Sequence, Union
 
@@ -368,9 +369,71 @@ def first_place_votes(
         profile, [1] + [0] * (profile.max_ranking_length - 1), tie_convention
     )
 
-def mentions(profile: RankProfile) -> dict[str, float]:
+
+def _ballots_are_materialized(profile: RankProfile) -> bool:
     """
-    Calculates total mentions for all candidates in a ``RankProfile``.
+    Checks if the ballots are materialized in a ``RankProfile``.
+
+    Args:
+        profile (RankProfile): RankProfile of ballots.
+
+    Returns:
+        bool:
+            True if ballots are materialized, False otherwise.
+    """
+    return "ballots" in profile.__dict__
+
+
+def _mentions_from_df(profile: RankProfile) -> dict[str, Fraction]:
+    """
+    Faster pandas-based mentions calculator for RankProfiles where ballots are not materialized.
+
+    Args:
+        profile (RankProfile): RankProfile of ballots.
+
+    Returns:
+        dict[str, float]:
+            Dictionary mapping candidates to mention totals (values).
+    """
+    assert profile.max_ranking_length is not None
+
+    ranking_cols = [
+        f"Ranking_{i}"
+        for i in range(1, profile.max_ranking_length + 1)
+    ]
+
+    tilde = frozenset({"~"})
+
+    rank_sets = profile.df[ranking_cols].stack()
+
+    rank_sets = rank_sets[
+        rank_sets.map(
+            lambda s: isinstance(s, frozenset) and bool(s) and s != tilde
+        )
+    ]
+
+    exploded = rank_sets.explode()
+
+    if exploded.empty:
+        return {c: Fraction(0) for c in profile.candidates}
+
+    weights = profile.df["Weight"].reindex(
+        exploded.index.get_level_values(0)
+    ).to_numpy()
+
+    totals = pd.Series(weights).groupby(exploded.to_numpy(), sort=False).sum()
+
+    return {
+        c: totals.get(c, Fraction(0))
+        for c in profile.candidates
+    }
+
+
+def fast_mentions(profile: RankProfile) -> dict[str, Fraction]:
+    """
+    Decides which way to compute mentions based on whether ballots are materialized in the profile. 
+    If they are, uses the traditional mentions calculation. 
+    If not, uses a faster pandas-based approach.
 
     Args:
         profile (RankProfile): RankProfile of ballots.
@@ -382,34 +445,13 @@ def mentions(profile: RankProfile) -> dict[str, float]:
     if not isinstance(profile, RankProfile):
         raise TypeError("Profile must be of type RankProfile.")
 
-    assert profile.max_ranking_length is not None
+    if _ballots_are_materialized(profile):
+        return mentions(profile)
 
-    ranking_cols = [
-        f"Ranking_{i}"
-        for i in range(1, profile.max_ranking_length + 1)
-    ]
+    return _mentions_from_df(profile)
 
-    rank_sets = profile.df[ranking_cols].stack()
 
-    tilde = frozenset({"~"})
-    rank_sets = rank_sets[
-        rank_sets.map(lambda s: bool(s) and s != tilde)
-    ]
-
-    exploded = rank_sets.explode()
-
-    weights = profile.df["Weight"].reindex(
-        exploded.index.get_level_values(0)
-    )
-
-    totals = weights.groupby(exploded).sum()
-
-    return {
-        c: float(totals.get(c, 0.0))
-        for c in profile.candidates
-    }
-
-def old_mentions(
+def mentions(
     profile: RankProfile,
 ) -> dict[str, float]:
     """

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -368,8 +368,48 @@ def first_place_votes(
         profile, [1] + [0] * (profile.max_ranking_length - 1), tie_convention
     )
 
+def mentions(profile: RankProfile) -> dict[str, float]:
+    """
+    Calculates total mentions for all candidates in a ``RankProfile``.
 
-def mentions(
+    Args:
+        profile (RankProfile): RankProfile of ballots.
+
+    Returns:
+        dict[str, float]:
+            Dictionary mapping candidates to mention totals (values).
+    """
+    if not isinstance(profile, RankProfile):
+        raise TypeError("Profile must be of type RankProfile.")
+
+    assert profile.max_ranking_length is not None
+
+    ranking_cols = [
+        f"Ranking_{i}"
+        for i in range(1, profile.max_ranking_length + 1)
+    ]
+
+    rank_sets = profile.df[ranking_cols].stack()
+
+    tilde = frozenset({"~"})
+    rank_sets = rank_sets[
+        rank_sets.map(lambda s: bool(s) and s != tilde)
+    ]
+
+    exploded = rank_sets.explode()
+
+    weights = profile.df["Weight"].reindex(
+        exploded.index.get_level_values(0)
+    )
+
+    totals = weights.groupby(exploded).sum()
+
+    return {
+        c: float(totals.get(c, 0.0))
+        for c in profile.candidates
+    }
+
+def old_mentions(
     profile: RankProfile,
 ) -> dict[str, float]:
     """

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -1,7 +1,7 @@
 import math
 import random
 from itertools import permutations
-from typing import Literal, Optional, Sequence, Union, cast
+from typing import Any, Literal, Optional, Sequence, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -386,33 +386,37 @@ def _ballots_are_materialized(profile: RankProfile) -> bool:
 def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     assert profile.max_ranking_length is not None
 
-    ranking_cols = [f"Ranking_{i}" for i in range(1, profile.max_ranking_length + 1)]
+    ranking_cols = [
+        f"Ranking_{i}"
+        for i in range(1, profile.max_ranking_length + 1)
+    ]
 
     tilde = frozenset({"~"})
 
-    rank_sets = cast(
-        pd.Series,
-        profile.df[ranking_cols].stack(),
-    )
+    rank_sets = cast(Any, profile.df[ranking_cols].stack())
 
-    mask = cast(
-        pd.Series,
-        rank_sets.map(lambda s: isinstance(s, frozenset) and bool(s) and s != tilde),
-    )
+    mask = rank_sets.map(
+            lambda s: isinstance(s, frozenset) and bool(s) and s != tilde
+        )
 
     rank_sets = rank_sets[mask]
-
     exploded = rank_sets.explode()
 
     if exploded.empty:
         return {c: 0.0 for c in profile.candidates}
 
-    weights = profile.df["Weight"].reindex(exploded.index.get_level_values(0)).to_numpy()
+    weights = (
+        profile.df["Weight"]
+        .reindex(exploded.index.get_level_values(0))
+        .to_numpy()
+    )
 
     totals = pd.Series(weights).groupby(exploded.to_numpy(), sort=False).sum()
 
-    return {c: totals.get(c, 0.0) for c in profile.candidates}
-
+    return {
+        c: totals.get(c, 0.0)
+        for c in profile.candidates
+    }
 
 def fast_mentions(profile: RankProfile) -> dict[str, float]:
     """

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -1,7 +1,7 @@
 import math
 import random
 from itertools import permutations
-from typing import Any, Literal, Optional, Sequence, Union, cast
+from typing import Literal, Optional, Sequence, Union, cast
 
 import numpy as np
 import pandas as pd

--- a/src/votekit/utils.py
+++ b/src/votekit/utils.py
@@ -1,8 +1,8 @@
 import math
 import random
 from itertools import permutations
-from typing import Literal, Optional, Sequence, Union
-from typing import Any, cast
+from typing import Any, Literal, Optional, Sequence, Union, cast
+
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
@@ -386,23 +386,18 @@ def _ballots_are_materialized(profile: RankProfile) -> bool:
 def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     assert profile.max_ranking_length is not None
 
-    ranking_cols = [
-        f"Ranking_{i}"
-        for i in range(1, profile.max_ranking_length + 1)
-    ]
+    ranking_cols = [f"Ranking_{i}" for i in range(1, profile.max_ranking_length + 1)]
 
     tilde = frozenset({"~"})
 
     rank_sets = cast(
-        pd.Series[Any],
+        pd.Series,
         profile.df[ranking_cols].stack(),
     )
 
     mask = cast(
-        pd.Series[Any],
-        rank_sets.map(
-            lambda s: isinstance(s, frozenset) and bool(s) and s != tilde
-        ),
+        pd.Series,
+        rank_sets.map(lambda s: isinstance(s, frozenset) and bool(s) and s != tilde),
     )
 
     rank_sets = rank_sets[mask]
@@ -412,24 +407,17 @@ def _mentions_from_df(profile: RankProfile) -> dict[str, float]:
     if exploded.empty:
         return {c: 0.0 for c in profile.candidates}
 
-    weights = (
-        profile.df["Weight"]
-        .reindex(exploded.index.get_level_values(0))
-        .to_numpy()
-    )
+    weights = profile.df["Weight"].reindex(exploded.index.get_level_values(0)).to_numpy()
 
     totals = pd.Series(weights).groupby(exploded.to_numpy(), sort=False).sum()
 
-    return {
-        c: totals.get(c, 0.0)
-        for c in profile.candidates
-    }
+    return {c: totals.get(c, 0.0) for c in profile.candidates}
 
 
 def fast_mentions(profile: RankProfile) -> dict[str, float]:
     """
-    Decides which way to compute mentions based on whether ballots are materialized in the profile. 
-    If they are, uses the traditional mentions calculation. 
+    Decides which way to compute mentions based on whether ballots are materialized in the profile.
+    If they are, uses the traditional mentions calculation.
     If not, uses a faster pandas-based approach.
 
     Args:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,7 +300,7 @@ def test_fast_mentions_with_duplicates():
 
 @pytest.mark.slow
 def test_fast_and_slow_mentions_are_same():
-    profile = RankProfile.from_csv(CSV_DIR / "albany_profile.csv")
+    profile = cast(RankProfile, RankProfile.from_csv(CSV_DIR / "albany_profile.csv"))
     assert mentions(profile) == fast_mentions(profile)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from itertools import permutations
+from pathlib import Path
 from typing import Literal, cast
 
 import pytest
@@ -12,6 +13,7 @@ from votekit.utils import (
     borda_scores,
     elect_cands_from_set_ranking,
     expand_tied_ballot,
+    fast_mentions,
     first_place_votes,
     index_to_lexicographic_ballot,
     mentions,
@@ -23,6 +25,8 @@ from votekit.utils import (
     tiebroken_ranking,
     validate_score_vector,
 )
+
+CSV_DIR = Path(__file__).resolve().parents[0] / "data" / "csv"
 
 profile_no_ties = RankProfile(
     ballots=(
@@ -37,6 +41,14 @@ profile_with_ties = RankProfile(
         RankBallot(ranking=tuple(map(frozenset, [{"A", "B"}])), weight=1),
         RankBallot(ranking=tuple(map(frozenset, [{"A", "B", "C"}])), weight=1 / 2),
         RankBallot(ranking=tuple(map(frozenset, [{"A"}, {"C"}, {"B"}])), weight=3),
+    )
+)
+
+profile_with_duplicates = RankProfile(
+    ballots=(
+        RankBallot(ranking=tuple(map(frozenset, [{"A"}, {"B"}, {"B"}])), weight=1),
+        RankBallot(ranking=tuple(map(frozenset, [{"A"}, {"B"}, {"C"}])), weight=1 / 2),
+        RankBallot(ranking=tuple(map(frozenset, [{"B"}, {"B"}, {"B"}])), weight=3),
     )
 )
 
@@ -251,9 +263,55 @@ def test_mentions():
     assert isinstance(test["A"], float)
 
 
+def test_mentions_with_ties():
+    correct = {"A": 9 / 2, "B": 9 / 2, "C": 7 / 2}
+    test = mentions(profile_with_ties)
+    assert correct == test
+    assert isinstance(test["A"], float)
+
+
+def test_mentions_with_duplicates():
+    correct = {"A": 3 / 2, "B": 23 / 2, "C": 1 / 2}
+    test = mentions(profile_with_duplicates)
+    assert correct == test
+    assert isinstance(test["A"], float)
+
+
+def test_fast_mentions():
+    correct = {"A": 9 / 2, "B": 9 / 2, "C": 7 / 2}
+    test = fast_mentions(profile_no_ties)
+    assert correct == test
+    assert isinstance(test["A"], float)
+
+
+def test_fast_mentions_with_ties():
+    correct = {"A": 9 / 2, "B": 9 / 2, "C": 7 / 2}
+    test = fast_mentions(profile_with_ties)
+    assert correct == test
+    assert isinstance(test["A"], float)
+
+
+def test_fast_mentions_with_duplicates():
+    correct = {"A": 3 / 2, "B": 23 / 2, "C": 1 / 2}
+    test = fast_mentions(profile_with_duplicates)
+    assert correct == test
+    assert isinstance(test["A"], float)
+
+
+@pytest.mark.slow
+def test_fast_and_slow_mentions_are_same():
+    profile = RankProfile.from_csv(CSV_DIR / "albany_profile.csv")
+    assert mentions(profile) == fast_mentions(profile)
+
+
 def test_mentions_errors():
     with pytest.raises(TypeError, match="Profile must be of type RankProfile"):
         mentions(cast(RankProfile, ScoreProfile(ballots=(ScoreBallot(scores={"A": 3}),))))
+
+
+def test_fast_mentions_errors():
+    with pytest.raises(TypeError, match="Profile must be of type RankProfile"):
+        fast_mentions(cast(RankProfile, ScoreProfile(ballots=(ScoreBallot(scores={"A": 3}),))))
 
 
 def test_borda_no_ties():


### PR DESCRIPTION
I got tired of waiting >5 seconds every time I need to compute mentions for large profiles.

The legacy mentions function in `votekit/utils` uses the Profile's `.ballots` property to compute ballots; when this property is not already set, it is computed and cached when `mentions` is called. This is quite slow when we are passing a large profile that was loaded via a cvr loader that relies on a pandas df rather than a list of ballots to create the profile. This PR introduces a new pandas-only way to compute mentions in such a case, which is around 14-20x faster on my machine for the Portland profiles.

When the ballot list *is* already materialized, the legacy `mentions` *are* faster; in such a case the `fast_mentions` function I'm adding defaults back to said legacy function.

I also add a few extra tests for both the old and the new mentions functions to verify intended behavior on profiles with repeated and tied rankings (although the former is probably not the intended use case).

Some things worth considering as part of this PR:
- I kept the old mentions calculator as the one named `mentions` here, and I named my addition `fast_mentions`; we might just want to replace `mentions` completely instead.
- This might be a good opportunity to allow compatibility with `Fraction` outputs, if we care (cf. Issue #358). I am happy to do this if desired (this would involve me chasing down other places mentions are used in votekit and tinkering with the typing).