### PR TITLE
Feat/simplify rank ballot input

### DIFF
--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -176,14 +176,22 @@ class RankBallot(Ballot):
     ):
         if scores is not None:
             raise TypeError("Only one of ranking or scores can be provided.")
-        ranking = self._convert_ranking_candidates_to_str_strip_whitespace(ranking)
+        ranking = self._convert_ranking_candidates_to_frozenset_strip_whitespace(ranking)
         self._validate_ranking_candidates(ranking)
         self.ranking = ranking
         super().__init__(weight=weight, voter_set=voter_set)
 
-    def _convert_ranking_candidates_to_str_strip_whitespace(self, ranking: RankingLike) -> Ranking:
+    def _convert_ranking_candidates_to_frozenset_strip_whitespace(
+        self, ranking: RankingLike
+    ) -> Ranking:
         if ranking is None:
             return None
+        if isinstance(ranking, str):
+            raise TypeError(
+                f"Received ranking `{ranking}` of type {type(ranking).__name__}."
+                " If you intended this to be a bullet vote, then wrap it in a list."
+            )
+
         normalized_ranking = []
         for cand_set in ranking:
             if isinstance(cand_set, str):

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -4,7 +4,7 @@ from numbers import Real
 from typing import Iterable, Optional, Sequence, TypeAlias, Union, overload
 
 Ranking: TypeAlias = Optional[tuple[frozenset[str], ...]]
-RankingLike: TypeAlias = Optional[Sequence[Iterable[str]]]
+RankingLike: TypeAlias = Optional[Sequence[str | Iterable[str]]]
 
 
 class Ballot:
@@ -49,7 +49,7 @@ class Ballot:
     def __new__(
         cls,
         *,
-        ranking: Sequence[Iterable[str]],
+        ranking: Sequence[str | Iterable[str]],
         scores: None = None,
         weight: Union[float, int] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
@@ -69,7 +69,7 @@ class Ballot:
     def __new__(
         cls,
         *,
-        ranking: Optional[Sequence[Iterable[str]]] = None,
+        ranking: Optional[Sequence[str | Iterable[str]]] = None,
         scores: Optional[dict[str, Union[int, float]]] = None,
         weight: Union[float, int] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
@@ -78,7 +78,7 @@ class Ballot:
     def __new__(
         cls,
         *,
-        ranking: Optional[Sequence[Iterable[str]]] = None,
+        ranking: Optional[Sequence[str | Iterable[str]]] = None,
         scores: Optional[dict[str, Union[int, float]]] = None,
         weight: Union[float, int] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
@@ -95,7 +95,7 @@ class Ballot:
     def __init__(
         self,
         *,
-        ranking: Optional[Sequence[Iterable[str]]] = None,
+        ranking: Optional[Sequence[str | Iterable[str]]] = None,
         scores: Optional[dict[str, Union[int, float]]] = None,
         weight: Union[float, int] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
@@ -176,11 +176,23 @@ class RankBallot(Ballot):
     ):
         if scores is not None:
             raise TypeError("Only one of ranking or scores can be provided.")
+        ranking = self._normalize_and_strip_whitespace_ranking_candidates(ranking)
         self._validate_ranking_candidates(ranking)
-        self.ranking = self._strip_whitespace_ranking_candidates(ranking)
+        self.ranking = ranking
         super().__init__(weight=weight, voter_set=voter_set)
 
-    def _validate_ranking_candidates(self, ranking: RankingLike):
+    def _normalize_and_strip_whitespace_ranking_candidates(self, ranking: RankingLike) -> Ranking:
+        if ranking is None:
+            return None
+        normalized_ranking = []
+        for cand_set in ranking:
+            if isinstance(cand_set, str):
+                normalized_ranking.append(frozenset({cand_set.strip()}))
+            else:
+                normalized_ranking.append(frozenset(c.strip() for c in cand_set))
+        return tuple(normalized_ranking)
+
+    def _validate_ranking_candidates(self, ranking: Ranking):
         if ranking is None:
             return
         if any(c == "~" for cand_set in ranking for c in cand_set):
@@ -189,12 +201,6 @@ class RankBallot(Ballot):
                 " '~' is a reserved character and cannot be used for"
                 " candidate names."
             )
-
-    def _strip_whitespace_ranking_candidates(self, ranking: RankingLike) -> Ranking:
-        if ranking is None:
-            return None
-
-        return tuple([frozenset(c.strip() for c in cand_set) for cand_set in ranking])
 
     def __eq__(self, other):
         if not isinstance(other, RankBallot):

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -12,9 +12,9 @@ class Ballot:
     Ballot parent class, contains voter set and assigned weight.
 
     Args:
-        ranking (Optional[Sequence[str | Iterable[str]]]): Candidate ranking. Entry i of the
-            sequence is an iterable of candidates ranked in position i. Defaults to None.
-            Will be coerced to tuple[frozenset[str], ...].
+        ranking (Optional[Sequence[str | Iterable[str]]]): Candidate ranking.
+            Entry i of the sequence is a candidate or iterable of candidates ranked in position i.
+            Defaults to None. Will be coerced to tuple[frozenset[str], ...].
         weight (Union[float, int]): Weight assigned to a given ballot. Defaults to 1.0
             Can be input as int or float, and will be coerced to float.
         voter_set (Union[set[str], frozenset[str]]): Set of voters who cast the ballot.
@@ -188,8 +188,8 @@ class RankBallot(Ballot):
             return None
         if isinstance(ranking, str):
             raise TypeError(
-                f"Received ranking `{ranking}` of type {type(ranking).__name__}."
-                " If you intended this to be a bullet vote, then wrap it in a list."
+                f"Received ranking `{ranking}` of type {type(ranking).__name__}. "
+                "If you intended this to be a bullet vote, then wrap it in a list."
             )
 
         normalized_ranking = []

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -176,12 +176,12 @@ class RankBallot(Ballot):
     ):
         if scores is not None:
             raise TypeError("Only one of ranking or scores can be provided.")
-        ranking = self._normalize_and_strip_whitespace_ranking_candidates(ranking)
+        ranking = self._convert_ranking_candidates_to_str_strip_whitespace(ranking)
         self._validate_ranking_candidates(ranking)
         self.ranking = ranking
         super().__init__(weight=weight, voter_set=voter_set)
 
-    def _normalize_and_strip_whitespace_ranking_candidates(self, ranking: RankingLike) -> Ranking:
+    def _convert_ranking_candidates_to_str_strip_whitespace(self, ranking: RankingLike) -> Ranking:
         if ranking is None:
             return None
         normalized_ranking = []

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -12,7 +12,7 @@ class Ballot:
     Ballot parent class, contains voter set and assigned weight.
 
     Args:
-        ranking (Optional[Sequence[Iterable[str]]]): Candidate ranking. Entry i of the
+        ranking (Optional[Sequence[str | Iterable[str]]]): Candidate ranking. Entry i of the
             sequence is an iterable of candidates ranked in position i. Defaults to None.
             Will be coerced to tuple[frozenset[str], ...].
         weight (Union[float, int]): Weight assigned to a given ballot. Defaults to 1.0

--- a/tests/ballot/test_RankBallot.py
+++ b/tests/ballot/test_RankBallot.py
@@ -148,3 +148,8 @@ def test_rank_sub_ballot():
 def test_rank_and_score():
     with pytest.raises(TypeError, match="Only one of ranking or scores can be provided."):
         RankBallot(ranking=[{"A"}], scores={"A": 1})
+
+
+def test_ballot_str_elements():
+    b = RankBallot(ranking=["A", "B", {"C"}], weight=1, voter_set={"A"})
+    assert b.ranking == (frozenset({"A"}), frozenset({"B"}), frozenset({"C"}))

--- a/tests/ballot/test_RankBallot.py
+++ b/tests/ballot/test_RankBallot.py
@@ -150,6 +150,13 @@ def test_rank_and_score():
         RankBallot(ranking=[{"A"}], scores={"A": 1})
 
 
-def test_ballot_str_elements():
-    b = RankBallot(ranking=["A", "B", {"C"}], weight=1, voter_set={"A"})
-    assert b.ranking == (frozenset({"A"}), frozenset({"B"}), frozenset({"C"}))
+def test_str_ranking_raises_type_error():
+    with pytest.raises(
+        TypeError, match="If you intended this to be a bullet vote, then wrap it in a list."
+    ):
+        RankBallot(ranking="A")
+
+
+def test_str_singleton_ranking_elements():
+    b = RankBallot(ranking=["AB", "B", {"C"}], weight=1, voter_set={"A"})
+    assert b.ranking == (frozenset({"AB"}), frozenset({"B"}), frozenset({"C"}))

--- a/tests/ballot/test_RankBallot.py
+++ b/tests/ballot/test_RankBallot.py
@@ -150,13 +150,35 @@ def test_rank_and_score():
         RankBallot(ranking=[{"A"}], scores={"A": 1})
 
 
-def test_str_ranking_raises_type_error():
+def test_single_char_str_ranking_raises_type_error():
     with pytest.raises(
         TypeError, match="If you intended this to be a bullet vote, then wrap it in a list."
     ):
         RankBallot(ranking="A")
 
 
+def test_mult_char_str_ranking_raises_type_error():
+    """
+    Regression test: Ties should be indicated by wrapping tied candidates in an iterable.
+    Previously, a string ranking would be accepted and split str elements into a tie.
+    This is not the intended behavior, and we want to raise a TypeError instead.
+    """
+    with pytest.raises(
+        TypeError, match="If you intended this to be a bullet vote, then wrap it in a list."
+    ):
+        RankBallot(ranking="AB")
+
+
 def test_str_singleton_ranking_elements():
-    b = RankBallot(ranking=["AB", "B", {"C"}], weight=1, voter_set={"A"})
-    assert b.ranking == (frozenset({"AB"}), frozenset({"B"}), frozenset({"C"}))
+    b = RankBallot(ranking=["A", "B", "C"], weight=1, voter_set={"A"})
+    assert b.ranking == (frozenset({"A"}), frozenset({"B"}), frozenset({"C"}))
+
+
+def test_mixed_str_and_iterable_ranking_elements():
+    b = RankBallot(ranking=["A", {"B", "C"}, "D", {"E"}], weight=1, voter_set={"A"})
+    assert b.ranking == (
+        frozenset({"A"}),
+        frozenset({"B", "C"}),
+        frozenset({"D"}),
+        frozenset({"E"}),
+    )

--- a/tests/elections/election_types/ranking/test_simultaneous_veto.py
+++ b/tests/elections/election_types/ranking/test_simultaneous_veto.py
@@ -12,7 +12,10 @@ from votekit.pref_profile import RankProfile
 # ---------------------------------------------------------------------------
 
 
-def make_profile(raw: dict[tuple[str, ...], float], max_ranking_length=None) -> RankProfile:
+def make_profile(
+    raw: dict[tuple[str | tuple[str, ...], ...], float],
+    max_ranking_length=None,
+) -> RankProfile:
     """Shorthand: {("A", "B", "C"): 3} -> RankBallot with that ranking and weight."""
     ballots = [RankBallot(ranking=ranking, weight=weight) for ranking, weight in raw.items()]
     if max_ranking_length is None:
@@ -138,7 +141,7 @@ class TestValidation:
             SimultaneousVeto(basic_profile, candidate_weights={"A": 1.0, "B": 1.0})
 
     def test_no_ranking(self):
-        ballots = [RankBallot(ranking="A", weight=1.0), RankBallot(weight=1.0)]
+        ballots = [RankBallot(ranking=("A",), weight=1.0), RankBallot(weight=1.0)]
         profile = RankProfile(ballots=ballots)
         with pytest.raises(ValueError, match="rankings"):
             SimultaneousVeto(profile)
@@ -251,7 +254,7 @@ class TestScoringTieConvention:
         """A and B are tied for first place."""
         return make_profile(
             {
-                ("AB",): 5,
+                (("A", "B"),): 5,
                 ("C",): 4.9,
                 ("D",): 1,
             },
@@ -264,7 +267,7 @@ class TestScoringTieConvention:
             {
                 (
                     "C",
-                    "AB",
+                    ("A", "B"),
                 ): 5,
             }
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,13 +70,13 @@ class TestShortBallot:
             ValueError,
             match="number of candidates exceeds the length of the longest ranking.",
         ):
-            _ = RankProfile(ballots=(RankBallot(ranking=("AB",), weight=5),))
+            _ = RankProfile(ballots=(RankBallot(ranking=({"A", "B"},), weight=5),))
 
     def test_legal_short_profile(self):
         profile = RankProfile(
             ballots=(
                 RankBallot(
-                    ranking=("AB",),
+                    ranking=({"A", "B"},),
                     weight=5,
                 ),
             ),


### PR DESCRIPTION
Closes #353 

Relaxes the input requirements for `RankBallot.ranking` so that singleton positions can be provided as bare candidates instead of singleton sets.

Before:
```python
Ballot(ranking=[{"A"}, {"B"}, {"C", "D"}], weight=3)
```

After:

```python
Ballot(ranking=["A", "B", {"C", "D"}], weight=3)
```

## Implementation
Normalization happens at construction where the input is converted to `type[frozenset[str], ...]` within initialization. Validation of ranking is moved after normalization (includes stripping whitespace) to catch `"~ "`  as candidate input. 

## Test
Added case for mixed rankings. Confirms `["A"]` is the same ballot as `[{"A"}]`