### PR TITLE
Feat/sort pref interval strengths descending

### DIFF
--- a/src/votekit/pref_interval.py
+++ b/src/votekit/pref_interval.py
@@ -84,7 +84,12 @@ class PreferenceInterval:
 
     @classmethod
     def from_dirichlet(
-        cls, candidates: list[str], alpha: float, *, allow_zero_support: bool = False
+        cls,
+        candidates: list[str],
+        alpha: float,
+        *,
+        allow_zero_support: bool = False,
+        sort_strengths_descending: bool = False,
     ):
         """
         Samples a PreferenceInterval from the Dirichlet distribution on the candidate simplex.
@@ -96,6 +101,9 @@ class PreferenceInterval:
             alpha (float): Alpha parameter for Dirichlet distribution.
             allow_zero_support (bool): If True, candidates with zero support are allowed. If False,
                 all candidates must have strictly positive support.
+            sort_strengths_descending (bool):
+                If True, the candidates are assigned their support values in descending order.
+                If False, the candidates are assigned support values in random order.
 
         Returns:
             PreferenceInterval
@@ -105,8 +113,14 @@ class PreferenceInterval:
         if not allow_zero_support:
             probs = [p + 10e-12 if p == 0 else p for p in probs]
 
+        pref_interval = (
+            {c: s for c, s in zip(candidates, sorted(probs, reverse=True))}
+            if sort_strengths_descending
+            else {c: s for c, s in zip(candidates, probs)}
+        )
+
         return cls(
-            {c: s for c, s in zip(candidates, probs)},
+            pref_interval,
             allow_zero_support=allow_zero_support,
         )
 

--- a/src/votekit/pref_interval.py
+++ b/src/votekit/pref_interval.py
@@ -102,7 +102,8 @@ class PreferenceInterval:
             allow_zero_support (bool): If True, candidates with zero support are allowed. If False,
                 all candidates must have strictly positive support.
             sort_strengths_descending (bool):
-                If True, the candidates are assigned their support values in descending order.
+                If True, the candidates are assigned their support values in descending order
+                according to the list passed to candidates.
                 If False, the candidates are assigned support values in random order.
 
         Returns:
@@ -114,9 +115,12 @@ class PreferenceInterval:
             probs = [p + 10e-12 if p == 0 else p for p in probs]
 
         pref_interval = (
-            {c: s for c, s in zip(candidates, sorted(probs, reverse=True))}
+            {
+                cand: strength
+                for cand, strength in zip(candidates, sorted(probs, reverse=True), strict=True)
+            }
             if sort_strengths_descending
-            else {c: s for c, s in zip(candidates, probs)}
+            else {cand: strength for cand, strength in zip(candidates, probs, strict=True)}
         )
 
         return cls(

--- a/tests/test_pref_interval.py
+++ b/tests/test_pref_interval.py
@@ -93,7 +93,7 @@ def test_combine():
 
 
 def test_sort_strengths_descending_from_dirchlet():
-    for i in range(50):
+    for _ in range(50):
         candidates = ["A", "B", "C"]
         pref_interval = PreferenceInterval.from_dirichlet(
             candidates=candidates, alpha=1, sort_strengths_descending=True

--- a/tests/test_pref_interval.py
+++ b/tests/test_pref_interval.py
@@ -93,21 +93,12 @@ def test_combine():
 
 
 def test_sort_strengths_descending_from_dirchlet():
-    candidates = ["A", "B", "C"]
-    pi = PreferenceInterval.from_dirichlet(
-        candidates=candidates, alpha=1, sort_strengths_descending=True
-    )
-    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
-    assert sorted_candidates == candidates
-
-    pi = PreferenceInterval.from_dirichlet(
-        candidates=candidates, alpha=1, sort_strengths_descending=True
-    )
-    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
-    assert sorted_candidates == candidates
-
-    pi = PreferenceInterval.from_dirichlet(
-        candidates=candidates, alpha=1, sort_strengths_descending=True
-    )
-    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
-    assert sorted_candidates == candidates
+    for i in range(50):
+        candidates = ["A", "B", "C"]
+        pref_interval = PreferenceInterval.from_dirichlet(
+            candidates=candidates, alpha=1, sort_strengths_descending=True
+        )
+        sorted_candidates = sorted(
+            pref_interval.interval, key=lambda c: pref_interval.interval[c], reverse=True
+        )
+        assert sorted_candidates == candidates

--- a/tests/test_pref_interval.py
+++ b/tests/test_pref_interval.py
@@ -90,3 +90,24 @@ def test_combine():
     )
 
     assert combined_pi == true_result
+
+
+def test_sort_strengths_descending_from_dirchlet():
+    candidates = ["A", "B", "C"]
+    pi = PreferenceInterval.from_dirichlet(
+        candidates=candidates, alpha=1, sort_strengths_descending=True
+    )
+    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
+    assert sorted_candidates == candidates
+
+    pi = PreferenceInterval.from_dirichlet(
+        candidates=candidates, alpha=1, sort_strengths_descending=True
+    )
+    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
+    assert sorted_candidates == candidates
+
+    pi = PreferenceInterval.from_dirichlet(
+        candidates=candidates, alpha=1, sort_strengths_descending=True
+    )
+    sorted_candidates = sorted(pi.interval, key=lambda c: pi.interval[c], reverse=True)
+    assert sorted_candidates == candidates


### PR DESCRIPTION
Closes #357 

`PreferenceInterval.from_dirichlet()` currently assigns preference strengths randomly to candidates. A flag has been added called `sort_strengths_descending` that will assign preference strengths in descending order to the `candidates` list if True. 

If user specifies `candidates = [A,B,C]` as input to `from_dirichlet`,  a preference interval of `[0.3, 0.6, 0.1]` could be randomly sampled. If `sort_strengths_descending = True`, `from_dirichlet` will return a `PreferenceInterval` with `interval = {A:0.6, B:0.3, C:0.1}`. If `sort_strengths_descending = False`, the preference interval would be assigned as is with `interval = {A:0.3, B:0.6, C:0.1}`.

This allows the user to specify an ordering to the preference_interval where they would like their first candidate listed with the highest preference strength, second candidate with the second preference strength, and so on. `sort_strengths_descending` is `False` by default. 

### Tests
Added one test that generates a preference interval 50x with `sort_strengths_descending = True` to account for the randomness of the preference interval sampling (i.e. could already be in strengths descending order)