### PR TITLE
Feat/fraction support

### DIFF
--- a/src/votekit/animations.py
+++ b/src/votekit/animations.py
@@ -395,7 +395,7 @@ class STVAnimation:
         """
         # Initialize dictionary and add "support" key for each candidate.
         candidate_dict: dict[Candidate, dict[str, object]] = {
-            name: {"support": support}
+            name: {"support": float(support)}
             for name, support in election.election_states[0].scores.items()
             if name in self.focus
         }
@@ -545,15 +545,29 @@ class STVAnimation:
             cand_transferred_from = cands_transferred_from[0]
             transfers = {cand_transferred_from: {}}
             for to_candidate in [c for s in current_state.remaining for c in s if c in self.focus]:
-                prev_score = prev_state.scores[to_candidate]
-                current_score = current_state.scores[to_candidate]
-                transfers[cand_transferred_from][to_candidate] = current_score - prev_score
+                prev_score = next(
+                    score
+                    for candidate, score in prev_state.scores.items()
+                    if candidate == to_candidate
+                )
+                current_score = next(
+                    score
+                    for candidate, score in current_state.scores.items()
+                    if candidate == to_candidate
+                )
+                transfers[cand_transferred_from][to_candidate] = float(current_score) - float(
+                    prev_score
+                )
         elif event_type == "win":
             ballots_by_fpv = ballots_by_first_cand(prev_profile)
             for cand_transferred_from in cands_transferred_from:
                 new_ballots = election.transfer(
                     cand_transferred_from,
-                    prev_state.scores[cand_transferred_from],
+                    next(
+                        score
+                        for candidate, score in prev_state.scores.items()
+                        if candidate == cand_transferred_from
+                    ),
                     ballots_by_fpv[cand_transferred_from],
                     election.threshold,
                 )
@@ -566,7 +580,7 @@ class STVAnimation:
                     if ballot.ranking is not None:
                         (to_candidate,) = ballot.ranking[0]
                         if to_candidate in self.focus:
-                            transfer_weights_from_candidate[to_candidate] += ballot.weight
+                            transfer_weights_from_candidate[to_candidate] += float(ballot.weight)
 
                 transfers[cand_transferred_from] = transfer_weights_from_candidate
 

--- a/src/votekit/ballot.py
+++ b/src/votekit/ballot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fractions import Fraction
 from numbers import Real
 from typing import Iterable, Mapping, Optional, Sequence, Union, overload
 
@@ -16,8 +17,8 @@ class Ballot:
             Entry i of the sequence is a candidate or iterable of candidates ranked in position i.
             Candidates can be strings, integers, or mix of both.
             Defaults to None. Will be coerced to tuple[frozenset[Candidate], ...].
-        weight (Union[float, int]): Weight assigned to a given ballot. Defaults to 1.0
-            Can be input as int or float, and will be coerced to float.
+        weight (Union[float, int, Fraction]): Weight assigned to a given ballot. Defaults to 1.0.
+            Rational weights are preserved for rank ballots; other weights are coerced to float.
         voter_set (Union[set[str], frozenset[str]]): Set of voters who cast the ballot.
             Defaults to frozenset(). Will be coerced to frozenset.
         scores (Optional[Mapping[Candidate, float | int] | Mapping[str, float | int]
@@ -31,7 +32,7 @@ class Ballot:
         ranking (Optional[tuple[frozenset[Candidate], ...]]): Tuple of candidate ranking.
             Entry i of the tuple is a frozenset of candidates ranked in position i.
             Candidates can be strings, integers, or mix of both.
-        weight (float): Weight assigned to a given ballot.
+        weight (float | Fraction): Weight assigned to a given ballot.
         voter_set (frozenset[str]): Set of voters who cast the ballot.
         scores (Optional[Mapping[Candidate, float | int]): Scores for individual candidates.
 
@@ -55,7 +56,7 @@ class Ballot:
         *,
         ranking: RankingLike,
         scores: None = None,
-        weight: Union[float, int] = 1.0,
+        weight: Union[float, int, Fraction] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
         include_zero_score: None = None,
     ) -> RankBallot: ...
@@ -87,7 +88,7 @@ class Ballot:
         *,
         ranking: RankingLike = None,
         scores: ScoresLike = None,
-        weight: Union[float, int] = 1.0,
+        weight: Union[float, int, Fraction] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
         include_zero_score: bool = False,
     ):
@@ -105,7 +106,7 @@ class Ballot:
         *,
         ranking: RankingLike = None,
         scores: ScoresLike = None,
-        weight: Union[float, int] = 1.0,
+        weight: Union[float, int, Fraction] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
     ):
         self.voter_set = frozenset(voter_set) if not isinstance(voter_set, frozenset) else voter_set
@@ -113,8 +114,11 @@ class Ballot:
         if weight < 0:
             raise ValueError("Ballot weight cannot be negative.")
 
-        # Silently promote weight to float
-        self.weight = float(weight)
+        self.weight = (
+            weight
+            if isinstance(self, RankBallot) and isinstance(weight, Fraction)
+            else float(weight)
+        )
         self._frozen = True
 
     def __eq__(self, other):
@@ -162,14 +166,14 @@ class RankBallot(Ballot):
         ranking (RankingLike): Ranking of candidates, defaults to None.
             RankingLike = Sequence[Candidate | Iterable[Candidate]] | None
             Canidates can be strings, integers, or mix of both.
-        weight (Union[int, float]): Weight of the ballot, defaults to 1.0.
+        weight (Union[int, float, Fraction]): Weight of the ballot, defaults to 1.0.
         voter_set (Union[set[str], frozenset[str]]): Voter set of the ballot,
             defaults to frozenset().
 
     Attributes:
         ranking (Ranking): Ranking of candidates.
             Ranking = tuple[frozenset[Candidate], ...] | None
-        weight (float): Weight of the ballot.
+        weight (float | Fraction): Weight of the ballot.
         voter_set (frozenset[str]): Voter set of the ballot.
 
     Raises:
@@ -184,7 +188,7 @@ class RankBallot(Ballot):
         *,
         ranking: RankingLike = None,
         scores: ScoresLike = None,
-        weight: Union[int, float] = 1.0,
+        weight: Union[int, float, Fraction] = 1.0,
         voter_set: Union[set[str], frozenset[str]] = frozenset(),
     ):
         if scores is not None:

--- a/src/votekit/cleaning/score_ballots_cleaning.py
+++ b/src/votekit/cleaning/score_ballots_cleaning.py
@@ -28,7 +28,7 @@ def remove_cand_score_ballot(
 
     new_ballot = ScoreBallot(
         scores=scores if scores != dict() else None,
-        weight=ballot.weight,
+        weight=float(ballot.weight),
         voter_set=ballot.voter_set,
     )
 

--- a/src/votekit/elections/election_state.py
+++ b/src/votekit/elections/election_state.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
-from votekit.types import Candidate
+from votekit.types import Candidate, CandidateNumericDict
 
 
 @dataclass
@@ -26,7 +26,7 @@ class ElectionState:
             tiebreak resolutions. Keys are frozensets of tied candidates and values are resolutions
             of tiebreak. Defaults to empty dictionary.
             Candidates can be strings, integers, or mix of both.
-        scores(dict[Candidate, float], optional): Stores score information.
+        scores (CandidateNumericDict, optional): Stores score information.
             Keys are candidates, values are scores. Only remaining candidates should be stored.
             Candidates can be strings, integers, or mix of both.
 
@@ -39,11 +39,13 @@ class ElectionState:
     tiebreaks: dict[frozenset[Candidate], tuple[frozenset[Candidate], ...]] = field(
         default_factory=dict
     )
-    scores: dict[Candidate, float] = field(default_factory=dict)
+    scores: CandidateNumericDict = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """
-        Convert the ElectionState to a dictionary representation.
+        Convert the ElectionState to a Python dictionary representation.
+
+        Score values are returned unchanged and may not be JSON serializable.
         """
         return {
             "round_number": self.round_number,

--- a/src/votekit/elections/election_types/ranking/abstract_ranking.py
+++ b/src/votekit/elections/election_types/ranking/abstract_ranking.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional
 from votekit.elections.election_state import ElectionState
 from votekit.models import Election
 from votekit.pref_profile import ProfileError, RankProfile
-from votekit.types import Candidate
+from votekit.types import CandidateNumericDict
 
 
 class RankingElection(Election[RankProfile]):
@@ -13,7 +13,7 @@ class RankingElection(Election[RankProfile]):
 
     Args:
         profile (RankProfile): The initial profile of ballots.
-        score_function (Callable[[RankProfile], dict[str | float, float]], optional):
+        score_function (Callable[[RankProfile], CandidateNumericDict], optional):
             A function that converts profiles to a score dictionary mapping candidates to
             their current score. Used in creating ElectionState objects and sorting candidates in
             Round 0. If None, no score dictionary is saved and all candidates are tied in Round 0.
@@ -25,7 +25,7 @@ class RankingElection(Election[RankProfile]):
         election_states (list[ElectionState]): a list of election states, one for each round of
             the election. The list is 0 indexed, so the initial state is stored at index 0, round 1
             at 1, etc.
-        score_function (Callable[[RankProfile], dict[Candidate, float]], optional):
+        score_function (Callable[[RankProfile], CandidateNumericDict], optional):
             A function that converts profiles to a score dictionary mapping candidates to
             their current score. Used in creating ElectionState objects. Defaults to None.
             Candidates can be strings, integers, or mix of both.
@@ -36,7 +36,7 @@ class RankingElection(Election[RankProfile]):
         self,
         profile: RankProfile,
         n_seats: int = 1,
-        score_function: Optional[Callable[[RankProfile], dict[Candidate, float]]] = None,
+        score_function: Optional[Callable[[RankProfile], CandidateNumericDict]] = None,
         sort_high_low: bool = True,
     ):
         if n_seats <= 0:

--- a/src/votekit/elections/election_types/ranking/alaska.py
+++ b/src/votekit/elections/election_types/ranking/alaska.py
@@ -13,7 +13,7 @@ from votekit.elections.election_types.ranking.stv.numpy_stv_base import (
 from votekit.elections.election_types.ranking.stv.stv import STV
 from votekit.elections.transfers import fractional_transfer
 from votekit.pref_profile import RankProfile
-from votekit.types import Candidate
+from votekit.types import Candidate, Numeric
 from votekit.utils import first_place_votes
 
 from .abstract_ranking import RankingElection
@@ -60,7 +60,7 @@ class Alaska(RankingElection):
         m_1: int = 2,
         m_2: int = 1,
         transfer: Callable[
-            [Candidate, float, Union[tuple[RankBallot], list[RankBallot]], int],
+            [Candidate, Numeric, Union[tuple[RankBallot], list[RankBallot]], int],
             tuple[RankBallot, ...],
         ] = fractional_transfer,
         quota: QuotaType | None = "droop",

--- a/src/votekit/elections/election_types/ranking/boosted_random_dictator.py
+++ b/src/votekit/elections/election_types/ranking/boosted_random_dictator.py
@@ -92,7 +92,7 @@ class BoostedRandomDictator(RankingElection):
         elif u <= 1 / (len(remaining_cands) - 1):
             fpv = prev_state.scores
             candidates = list(fpv.keys())
-            weights: list[float] = list(fpv.values())
+            weights = [float(weight) for weight in fpv.values()]
             sq_weights = [float(x) ** 2 for x in weights]
             sq_wt_total = sum(sq_weights)
             sq_weights = [x / sq_wt_total for x in sq_weights]
@@ -102,7 +102,7 @@ class BoostedRandomDictator(RankingElection):
         else:
             fpv = prev_state.scores
             candidates = list(fpv.keys())
-            weights = list(fpv.values())
+            weights = [float(weight) for weight in fpv.values()]
             idx = self._rng.choices(range(len(candidates)), weights=weights, k=1)[0]
             winning_candidate = candidates[idx]
 

--- a/src/votekit/elections/election_types/ranking/plurality_veto.py
+++ b/src/votekit/elections/election_types/ranking/plurality_veto.py
@@ -376,7 +376,7 @@ class _IterativeVetoBase(RankingElection, ABC):
                 )
         self._internal_round_number += 1
 
-        new_scores = prev_state.scores.copy()
+        new_scores = {candidate: float(score) for candidate, score in prev_state.scores.items()}
         remaining_set = self.candidates - self._eliminated
         if len(remaining_set) == self.n_seats:
             electable_candidates = remaining_set

--- a/src/votekit/elections/election_types/ranking/random_dictator.py
+++ b/src/votekit/elections/election_types/ranking/random_dictator.py
@@ -81,7 +81,7 @@ class RandomDictator(RankingElection):
         """
         fpv = prev_state.scores
         candidates = list(fpv.keys())
-        weights: list[float] = list(fpv.values())
+        weights = [float(weight) for weight in fpv.values()]
         idx = self._rng.choices(range(len(candidates)), weights=weights, k=1)[0]
         winning_cand = candidates[idx]
         elected = (frozenset({winning_cand}),)

--- a/src/votekit/elections/election_types/ranking/stv/exact_fraction_ops.py
+++ b/src/votekit/elections/election_types/ranking/stv/exact_fraction_ops.py
@@ -10,6 +10,10 @@ def to_exact_fraction_weight(value: object) -> Fraction:
     """
     Convert an exact STV ballot weight to a nonnegative ``Fraction``.
 
+    Warning:
+        Exact STV operations assume every ranking position contains at most one candidate. This
+        helper does not validate that profile-level precondition.
+
     Args:
         value (object): Ballot weight to convert. Integral real values and ``Fraction`` values
             are accepted.
@@ -52,6 +56,10 @@ def convert_profile_weights(
     """
     Return a copy of a rank profile with converted ballot weights.
 
+    Warning:
+        Exact STV operations assume every ranking position contains at most one candidate. This
+        helper does not validate that precondition.
+
     Args:
         profile (RankProfile): Profile whose weights are converted.
         converter (Callable[[Any], Numeric]): Function applied to each ballot weight.
@@ -73,6 +81,10 @@ def convert_profile_weights(
 def exact_first_place_votes(profile: RankProfile) -> dict[Candidate, Fraction]:
     """
     Compute exact first-place totals for an exact STV profile.
+
+    Warning:
+        The profile must already have passed STV validation. Tied ranking positions are not
+        supported.
 
     Args:
         profile (RankProfile): Profile with singleton rankings and ``Fraction`` weights.
@@ -99,6 +111,10 @@ def exact_borda_scores(profile: RankProfile) -> dict[Candidate, Fraction]:
     """
     Compute exact Borda scores for an exact STV profile.
 
+    Warning:
+        The profile must already have passed STV validation. Tied ranking positions are not
+        supported.
+
     Args:
         profile (RankProfile): Profile with singleton rankings and ``Fraction`` weights.
 
@@ -107,14 +123,19 @@ def exact_borda_scores(profile: RankProfile) -> dict[Candidate, Fraction]:
     """
     scores = {candidate: Fraction(0) for candidate in profile.candidates_cast}
     assert profile.max_ranking_length is not None
+    ranking_columns = [f"Ranking_{rank}" for rank in range(1, profile.max_ranking_length + 1)]
+    candidates_by_id = {}
+    for candidate_id, candidate_set in profile.id_candidate_map.items():
+        if candidate_id == -1:
+            continue
+        assert len(candidate_set) == 1
+        candidates_by_id[candidate_id] = next(iter(candidate_set))
 
-    for ballot in profile.ballots:
-        assert ballot.ranking is not None
-        assert isinstance(ballot.weight, Fraction)
-        for rank, candidate_set in enumerate(ballot.ranking):
-            if candidate_set == frozenset({"~"}):
+    ranking_rows = profile._df[ranking_columns].itertuples(index=False, name=None)
+    for candidate_ids, weight in zip(ranking_rows, profile._df["Weight"]):
+        assert isinstance(weight, Fraction)
+        for rank, candidate_id in enumerate(candidate_ids):
+            if candidate_id == -1:
                 break
-            assert len(candidate_set) == 1
-            candidate = next(iter(candidate_set))
-            scores[candidate] += ballot.weight * (profile.max_ranking_length - rank)
+            scores[candidates_by_id[candidate_id]] += weight * (profile.max_ranking_length - rank)
     return scores

--- a/src/votekit/elections/election_types/ranking/stv/exact_fraction_ops.py
+++ b/src/votekit/elections/election_types/ranking/stv/exact_fraction_ops.py
@@ -1,0 +1,120 @@
+from fractions import Fraction
+from numbers import Integral, Real
+from typing import Any, Callable, cast
+
+from votekit.pref_profile import RankProfile
+from votekit.types import Candidate, Numeric
+
+
+def to_exact_fraction_weight(value: object) -> Fraction:
+    """
+    Convert an exact STV ballot weight to a nonnegative ``Fraction``.
+
+    Args:
+        value (object): Ballot weight to convert. Integral real values and ``Fraction`` values
+            are accepted.
+
+    Returns:
+        Fraction: Exact ballot weight.
+
+    Raises:
+        TypeError: If the weight is not a real number.
+        ValueError: If the weight is negative, non-finite, or a non-integral float.
+    """
+    if isinstance(value, Fraction):
+        if value < 0:
+            raise ValueError("Ballot weight cannot be negative.")
+        return value
+    if isinstance(value, Integral):
+        if value < 0:
+            raise ValueError("Ballot weight cannot be negative.")
+        return Fraction(int(value))
+    if isinstance(value, Real):
+        try:
+            integer_value = int(cast(Any, value))
+        except (OverflowError, ValueError) as error:
+            raise ValueError("Ballot weight must be finite.") from error
+        if value < 0:
+            raise ValueError("Ballot weight cannot be negative.")
+        if value != integer_value:
+            raise ValueError(
+                "Exact STV requires integral float weights; pass Fraction(numerator, denominator) "
+                "for rational weights."
+            )
+        return Fraction(integer_value)
+    raise TypeError("Exact STV ballot weights must be real numbers.")
+
+
+def convert_profile_weights(
+    profile: RankProfile,
+    converter: Callable[[Any], Numeric],
+) -> RankProfile:
+    """
+    Return a copy of a rank profile with converted ballot weights.
+
+    Args:
+        profile (RankProfile): Profile whose weights are converted.
+        converter (Callable[[Any], Numeric]): Function applied to each ballot weight.
+
+    Returns:
+        RankProfile: Profile with converted weights and unchanged rankings and candidates.
+    """
+    converted_df = profile.df.copy()
+    converted_df["Weight"] = converted_df["Weight"].map(converter)
+    converted_profile = RankProfile(
+        df=converted_df,
+        candidates=profile.candidates,
+        max_ranking_length=profile.max_ranking_length,
+    )
+    assert isinstance(converted_profile, RankProfile)
+    return converted_profile
+
+
+def exact_first_place_votes(profile: RankProfile) -> dict[Candidate, Fraction]:
+    """
+    Compute exact first-place totals for an exact STV profile.
+
+    Args:
+        profile (RankProfile): Profile with singleton rankings and ``Fraction`` weights.
+
+    Returns:
+        dict[Candidate, Fraction]: First-place total for every candidate, including zero totals.
+    """
+    scores = {candidate: Fraction(0) for candidate in profile.candidates_cast}
+    if profile._df.empty:
+        return scores
+
+    for candidate_id, weight in zip(profile._df["Ranking_1"], profile._df["Weight"]):
+        if candidate_id == -1:
+            continue
+        candidate_set = profile.id_candidate_map[candidate_id]
+        assert len(candidate_set) == 1
+        candidate = next(iter(candidate_set))
+        assert isinstance(weight, Fraction)
+        scores[candidate] += weight
+    return scores
+
+
+def exact_borda_scores(profile: RankProfile) -> dict[Candidate, Fraction]:
+    """
+    Compute exact Borda scores for an exact STV profile.
+
+    Args:
+        profile (RankProfile): Profile with singleton rankings and ``Fraction`` weights.
+
+    Returns:
+        dict[Candidate, Fraction]: Exact Borda score for every candidate.
+    """
+    scores = {candidate: Fraction(0) for candidate in profile.candidates_cast}
+    assert profile.max_ranking_length is not None
+
+    for ballot in profile.ballots:
+        assert ballot.ranking is not None
+        assert isinstance(ballot.weight, Fraction)
+        for rank, candidate_set in enumerate(ballot.ranking):
+            if candidate_set == frozenset({"~"}):
+                break
+            assert len(candidate_set) == 1
+            candidate = next(iter(candidate_set))
+            scores[candidate] += ballot.weight * (profile.max_ranking_length - rank)
+    return scores

--- a/src/votekit/elections/election_types/ranking/stv/stv.py
+++ b/src/votekit/elections/election_types/ranking/stv/stv.py
@@ -1,7 +1,7 @@
 import random
 from fractions import Fraction
 from functools import partial
-from typing import Callable, Literal, Optional, TypeAlias, Union
+from typing import Callable, Literal, Optional, TypeAlias, Union, cast
 from warnings import warn
 
 import numpy as np
@@ -60,10 +60,7 @@ def _candidate_score(scores: CandidateNumericDict, candidate: Candidate) -> Nume
     Raises:
         KeyError: If the candidate is absent from the score mapping.
     """
-    for scored_candidate, score in scores.items():
-        if scored_candidate == candidate:
-            return score
-    raise KeyError(candidate)
+    return cast(dict[Candidate, Numeric], scores)[candidate]
 
 
 class NumpyInnerSTV(NumpySTVBase):

--- a/src/votekit/elections/election_types/ranking/stv/stv.py
+++ b/src/votekit/elections/election_types/ranking/stv/stv.py
@@ -1,6 +1,7 @@
 import random
+from fractions import Fraction
 from functools import partial
-from typing import Callable, Optional, Union
+from typing import Callable, Literal, Optional, TypeAlias, Union
 from warnings import warn
 
 import numpy as np
@@ -15,6 +16,12 @@ from votekit.cleaning import (
 from votekit.elections._deprecation import _handle_deprecated_kwargs
 from votekit.elections.election_state import ElectionState
 from votekit.elections.election_types.ranking.abstract_ranking import RankingElection
+from votekit.elections.election_types.ranking.stv.exact_fraction_ops import (
+    convert_profile_weights,
+    exact_borda_scores,
+    exact_first_place_votes,
+    to_exact_fraction_weight,
+)
 from votekit.elections.election_types.ranking.stv.numpy_stv_base import (
     ElectionPlay,
     NumpyElectionDataTracker,
@@ -27,7 +34,7 @@ from votekit.elections.election_types.ranking.stv.numpy_stv_base import (
 from votekit.elections.election_types.ranking.stv.utils import numpy_random_transfer
 from votekit.elections.transfers import fractional_transfer, random_transfer
 from votekit.pref_profile import ProfileError, RankProfile
-from votekit.types import Candidate
+from votekit.types import Candidate, CandidateNumericDict, Numeric
 from votekit.utils import (
     _first_place_votes_from_df_no_ties,
     ballots_by_first_cand,
@@ -35,6 +42,28 @@ from votekit.utils import (
     score_dict_to_ranking,
     tiebreak_set,
 )
+
+BasicSTVTiebreak: TypeAlias = TiebreakType | Literal["alphabetical", "lexicographic", "alph", "lex"]
+
+
+def _candidate_score(scores: CandidateNumericDict, candidate: Candidate) -> Numeric:
+    """
+    Look up a candidate in a numeric score mapping.
+
+    Args:
+        scores (CandidateNumericDict): Candidate scores.
+        candidate (Candidate): Candidate whose score is requested.
+
+    Returns:
+        Numeric: Candidate score.
+
+    Raises:
+        KeyError: If the candidate is absent from the score mapping.
+    """
+    for scored_candidate, score in scores.items():
+        if scored_candidate == candidate:
+            return score
+    raise KeyError(candidate)
 
 
 class NumpyInnerSTV(NumpySTVBase):
@@ -733,24 +762,41 @@ class FastSequentialRCV(NumpyInnerSTV):
         )
 
 
+TransferFn: TypeAlias = Callable[
+    [Candidate, Numeric, Union[tuple[RankBallot], list[RankBallot]], int],
+    tuple[RankBallot, ...],
+]
+"""Signature for STV transfer functions.
+
+Called with the elected candidate, their first-place votes, the ballots that rank them first, and
+the election threshold; returns the transferred ballots.
+"""
+
+
 class STV(RankingElection):
     """
     STV elections. All ballots must have no ties.
     """
 
+    _LEXICOGRAPHIC_TIEBREAKS = frozenset({"alphabetical", "lexicographic", "alph", "lex"})
+    _ALLOWED_TIEBREAKS = _LEXICOGRAPHIC_TIEBREAKS | {
+        None,
+        "borda",
+        "first_place",
+        "random",
+    }
+
     def __init__(
         self,
         profile: RankProfile,
         n_seats: int | None = None,
-        transfer: Callable[
-            [Candidate, float, Union[tuple[RankBallot], list[RankBallot]], int],
-            tuple[RankBallot, ...],
-        ] = fractional_transfer,
+        transfer: TransferFn = fractional_transfer,
         quota: QuotaType | None = "droop",
         simultaneous: bool = True,
-        tiebreak: TiebreakType | None = None,
+        tiebreak: BasicSTVTiebreak | None = None,
         *,
         rng_seed: Optional[int] = None,
+        exact: bool = False,
         **kwargs,
     ):
         kwargs = _handle_deprecated_kwargs(kwargs, {"m": "n_seats"})
@@ -766,23 +812,27 @@ class STV(RankingElection):
         Args:
             profile (RankProfile): RankProfile to run election on.
             n_seats (int): Number of seats to be elected. Defaults to 1.
-            transfer (Callable[[Candidate, float, Union[tuple[RankBallot], list[RankBallot]], int],
-                tuple[RankBallot, ...]]): Transfer method. Defaults to fractional transfer.
+            transfer (TransferFn): Transfer method. Defaults to fractional transfer.
                 Function signature is elected candidate, their number of first-place votes, the list
                 of ballots with them ranked first, the threshold value, and a Random Number
                 Generator object which can be seeded for reproducible results. Returns the list of
                 ballots after transfer. Candidates can be strings, integers, or mix of both.
+                In exact mode, custom transfer methods are responsible for preserving ``Fraction``
+                ballot weights.
             quota (QuotaType, optional): Formula to calculate quota. Accepts "droop" or "hare".
                 Defaults to "droop".
             simultaneous (bool, optional): True if all candidates who cross threshold in a round are
                 elected simultaneously. False if only the candidate with highest first-place votes
                 who crosses the threshold is elected in a round. Defaults to True.
-            tiebreak (TiebreakType | None, optional): Method to be used if a tiebreak is
-                needed. Accepts "borda" and "random". Defaults to None, in which case a
-                ValueError is raised if a tiebreak is needed.
+            tiebreak (TiebreakType | None, optional): Method to be used if a tiebreak is needed.
+                Accepts "borda", "first_place", "random", and the lexicographic aliases
+                "alphabetical", "lexicographic", "alph", and "lex". Defaults to None, in which
+                case a ValueError is raised if a winner tiebreak is needed.
+            exact (bool): If True, use exact rational arithmetic for weights, scores, and
+                fractional transfers. Defaults to False.
             rng_seed (int, optional): Seed for random number generator. An integer seed produces the
-            same output given identical inputs; By default, seed is None which gives
-            non-deterministic results.
+                same output given identical inputs; By default, seed is None which gives
+                non-deterministic results.
         """
         self._stv_validate_profile(profile)
 
@@ -790,6 +840,17 @@ class STV(RankingElection):
             raise ValueError("n_seats must be positive.")
         self.n_seats = n_seats
         self.quota = quota
+        self.exact = exact
+
+        if exact:
+            if tiebreak not in self._ALLOWED_TIEBREAKS:
+                raise ValueError(
+                    "Exact STV supports only tiebreak=None, 'borda', 'first_place', 'random', "
+                    "or a lexicographic alias."
+                )
+            profile = convert_profile_weights(profile, to_exact_fraction_weight)
+        elif any(isinstance(weight, Fraction) for weight in profile._df["Weight"]):
+            profile = convert_profile_weights(profile, float)
 
         self.threshold = 0
         self.threshold = self.get_threshold(profile.total_ballot_wt)
@@ -804,7 +865,9 @@ class STV(RankingElection):
         super().__init__(
             profile,
             n_seats=n_seats,
-            score_function=_first_place_votes_from_df_no_ties,
+            score_function=(
+                exact_first_place_votes if exact else _first_place_votes_from_df_no_ties
+            ),
             sort_high_low=True,
         )
 
@@ -835,21 +898,28 @@ class STV(RankingElection):
             if (row == tilde).all():
                 raise TypeError("Ballots must have rankings.")
 
-    def get_threshold(self, total_ballot_wt: float) -> int:
+    def get_threshold(self, total_ballot_wt: Numeric) -> int:
         """
         Calculates threshold required for election.
 
         Args:
-            total_ballot_wt (float): Total weight of ballots to compute threshold.
+            total_ballot_wt (Numeric): Total weight of ballots to compute threshold.
 
         Returns:
             int: Value of the threshold.
         """
         if self.threshold == 0:
             if self.quota == "droop":
-                return int(total_ballot_wt / (self.n_seats + 1) + 1)  # takes floor
+                if self.exact and isinstance(total_ballot_wt, Fraction):
+                    return total_ballot_wt // (self.n_seats + 1) + 1
+                return int(float(total_ballot_wt) / (self.n_seats + 1) + 1)  # takes floor
             elif self.quota == "hare":
-                return int(total_ballot_wt / self.n_seats)  # takes floor
+                if self.exact and isinstance(total_ballot_wt, Fraction):
+                    threshold = total_ballot_wt // self.n_seats
+                    if threshold == 0:
+                        raise ValueError("Exact STV requires a positive Hare quota.")
+                    return threshold
+                return int(float(total_ballot_wt) / self.n_seats)  # takes floor
             else:
                 raise ValueError("Misspelled or unknown quota type.")
         else:
@@ -864,6 +934,81 @@ class STV(RankingElection):
         if len(elected_cands) == self.n_seats:
             return True
         return False
+
+    def _tiebreak_exact_losers(
+        self, candidates: frozenset[Candidate]
+    ) -> tuple[frozenset[Candidate], ...]:
+        """
+        Rank tied elimination candidates by their initial exact (fractional) scores.
+
+        Args:
+            candidates (frozenset[Candidate]): Candidates tied for elimination.
+
+        Returns:
+            tuple[frozenset[Candidate], ...]: Candidates ordered from highest to lowest score.
+
+        Raises:
+            TypeError: If an initial score is not a ``Fraction``.
+        """
+        initial_scores: dict[Candidate, Fraction] = {}
+        for candidate in candidates:
+            score = _candidate_score(self.election_states[0].scores, candidate)
+            if not isinstance(score, Fraction):
+                raise TypeError("Exact STV recorded a non-rational initial score.")
+            initial_scores[candidate] = score
+
+        return self._rank_exact_tiebreak_scores(candidates, initial_scores)
+
+    def _rank_exact_tiebreak_scores(
+        self,
+        candidates: frozenset[Candidate],
+        scores: dict[Candidate, Fraction],
+    ) -> tuple[frozenset[Candidate], ...]:
+        """
+        Rank candidates by exact (fractional) scores, using seeded randomness for remaining ties.
+
+        Args:
+            candidates (frozenset[Candidate]): Candidates to rank.
+            scores (dict[Candidate, Fraction]): Exact scores for the candidates.
+
+        Returns:
+            tuple[frozenset[Candidate], ...]: Candidates ordered from highest to lowest score.
+        """
+        ranking = score_dict_to_ranking({candidate: scores[candidate] for candidate in candidates})
+        return tuple(
+            singleton
+            for tied_set in ranking
+            for singleton in (
+                tiebreak_set(tied_set, tiebreak="random", rng=self._rng)
+                if len(tied_set) > 1
+                else (tied_set,)
+            )
+        )
+
+    def _tiebreak_exact_candidates(
+        self,
+        candidates: frozenset[Candidate],
+        profile: RankProfile,
+    ) -> tuple[frozenset[Candidate], ...]:
+        """
+        Resolve an exact (fraction) mode winner tie using the configured tiebreak.
+
+        Args:
+            candidates (frozenset[Candidate]): Candidates tied for election.
+            profile (RankProfile): Current profile used for numeric tiebreak scores.
+
+        Returns:
+            tuple[frozenset[Candidate], ...]: Candidates in resolved tiebreak order.
+        """
+        assert self.tiebreak is not None
+        if self.tiebreak == "random" or self.tiebreak in self._LEXICOGRAPHIC_TIEBREAKS:
+            return tiebreak_set(candidates, tiebreak=self.tiebreak, rng=self._rng)
+        if self.tiebreak == "first_place":
+            scores = exact_first_place_votes(profile)
+        else:
+            assert self.tiebreak == "borda"
+            scores = exact_borda_scores(profile)
+        return self._rank_exact_tiebreak_scores(candidates, scores)
 
     def _simultaneous_elect_step(
         self, profile: RankProfile, prev_state: ElectionState
@@ -892,7 +1037,7 @@ class STV(RankingElection):
         else:
             for s in ranking_by_fpv:
                 c = list(s)[0]  # all cands in set have same score
-                if prev_state.scores[c] >= self.threshold:
+                if _candidate_score(prev_state.scores, c) >= self.threshold:
                     elected.append(s)
 
                 # since ranking is ordered by fpv, once below threshold we are done
@@ -907,7 +1052,7 @@ class STV(RankingElection):
             for candidate in s:
                 transfer_ballots = self.transfer(
                     candidate,
-                    prev_state.scores[candidate],
+                    _candidate_score(prev_state.scores, candidate),
                     ballots_by_fpv[candidate],
                     self.threshold,
                 )
@@ -969,6 +1114,14 @@ class STV(RankingElection):
             elected = self.election_states[current_round].elected
             remaining = self.election_states[current_round].remaining
             tiebreaks = self.election_states[current_round].tiebreaks
+        elif self.exact and len(ranking_by_fpv[0]) > 1:
+            if self.tiebreak is None:
+                raise ValueError("Cannot elect correct number of candidates without breaking ties.")
+            tied_candidates = ranking_by_fpv[0]
+            tiebroken = self._tiebreak_exact_candidates(tied_candidates, profile)
+            elected = tiebroken[:1]
+            remaining = tiebroken[1:] + tuple(ranking_by_fpv[1:])
+            tiebreaks = {tied_candidates: tiebroken}
         else:
             elected, remaining, tiebreak = elect_cands_from_set_ranking(
                 ranking_by_fpv,
@@ -990,7 +1143,7 @@ class STV(RankingElection):
 
         transfer_ballots = self.transfer(
             elected_c,
-            prev_state.scores[elected_c],
+            _candidate_score(prev_state.scores, elected_c),
             ballots_by_fpv[elected_c],
             self.threshold,
         )
@@ -1081,12 +1234,15 @@ class STV(RankingElection):
                     if len(possible_tiebreaks) > 0:
                         tiebroken_ranking = possible_tiebreaks[0]
                 if tiebroken_ranking is None or len(tiebroken_ranking) == 0:
-                    tiebroken_ranking = tiebreak_set(
-                        lowest_fpv_cands,
-                        self.get_profile(0),
-                        tiebreak="first_place",
-                        rng=self._rng,
-                    )
+                    if self.exact:
+                        tiebroken_ranking = self._tiebreak_exact_losers(lowest_fpv_cands)
+                    else:
+                        tiebroken_ranking = tiebreak_set(
+                            lowest_fpv_cands,
+                            self.get_profile(0),
+                            tiebreak="first_place",
+                            rng=self._rng,
+                        )
 
                 tiebreaks = {lowest_fpv_cands: tiebroken_ranking}
 
@@ -1138,9 +1294,10 @@ class IRV(STV):
         self,
         profile: RankProfile,
         quota: QuotaType | None = "droop",
-        tiebreak: TiebreakType | None = None,
+        tiebreak: BasicSTVTiebreak | None = None,
         *,
         rng_seed: Optional[int] = None,
+        exact: bool = False,
     ):
         """
         Initialize an IRV election.
@@ -1154,10 +1311,20 @@ class IRV(STV):
                 None, in which case a ValueError is raised if a tiebreak is
                 needed.
             rng_seed (int, optional)): Seed for random number generator. An integer seed produces
-            the same output given identical inputs; By default, seed is None which gives
-            non-deterministic results.
+                the same output given identical inputs. By default, seed is None, which gives
+                non-deterministic results.
+            exact (bool): If True, preserve exact rational arithmetic for ballot weights, tallies,
+                thresholds, and tiebreak scores. IRV does not perform fractional surplus
+                reweighting. Defaults to False.
         """
-        super().__init__(profile, n_seats=1, quota=quota, tiebreak=tiebreak, rng_seed=rng_seed)
+        super().__init__(
+            profile,
+            n_seats=1,
+            quota=quota,
+            tiebreak=tiebreak,
+            rng_seed=rng_seed,
+            exact=exact,
+        )
 
 
 class SequentialRCV(STV):
@@ -1178,9 +1345,10 @@ class SequentialRCV(STV):
         n_seats: int | None = None,
         quota: QuotaType | None = "droop",
         simultaneous: bool = True,
-        tiebreak: TiebreakType | None = None,
+        tiebreak: BasicSTVTiebreak | None = None,
         *,
         rng_seed: Optional[int] = None,
+        exact: bool = False,
         **kwargs,
     ):
         """
@@ -1198,8 +1366,11 @@ class SequentialRCV(STV):
                 needed. Accepts "borda" and "random". Defaults to None, in which case a
                 ValueError is raised if a tiebreak is needed.
             rng_seed (int, optional): Seed for random number generator. An integer seed produces the
-            same output given identical inputs; By default, seed is None which gives
-            non-deterministic results.
+                same output given identical inputs. By default, seed is None, which gives
+                non-deterministic results.
+            exact (bool): If True, preserve exact rational arithmetic for ballot weights, tallies,
+                thresholds, and tiebreak scores. Sequential RCV removes winners without fractional
+                surplus reweighting. Defaults to False.
         """
         kwargs = _handle_deprecated_kwargs(kwargs, {"m": "n_seats"})
         if "n_seats" in kwargs:
@@ -1211,7 +1382,7 @@ class SequentialRCV(STV):
 
         def _transfer(
             winner: Candidate,
-            _fpv: float,
+            _fpv: Numeric,
             ballots: Union[tuple[RankBallot], list[RankBallot]],
             _threshold: int,
         ) -> tuple[RankBallot, ...]:
@@ -1240,4 +1411,5 @@ class SequentialRCV(STV):
             simultaneous=simultaneous,
             tiebreak=tiebreak,
             rng_seed=rng_seed,
+            exact=exact,
         )

--- a/src/votekit/elections/transfers.py
+++ b/src/votekit/elections/transfers.py
@@ -4,12 +4,12 @@ from typing import Optional, Union
 
 from votekit.ballot import RankBallot
 from votekit.pref_profile import RankProfile
-from votekit.types import Candidate
+from votekit.types import Candidate, Numeric
 
 
 def fractional_transfer(
     winner: Candidate,
-    fpv: float,
+    fpv: Numeric,
     ballots: Union[tuple[RankBallot], list[RankBallot]],
     threshold: int,
 ) -> tuple[RankBallot, ...]:
@@ -19,7 +19,7 @@ def fractional_transfer(
     Args:
         winner (Candidate): Candidate to transfer votes from.
             Candidate can be a string or integer.
-        fpv (float): Number of first place votes for winning candidate.
+        fpv (Numeric): Number of first place votes for winning candidate.
         ballots (Union[tuple[RankBallot], list[RankBallot]]): List of Ballot objects.
         threshold (int): Value required to be elected, used to calculate transfer value.
 
@@ -56,7 +56,7 @@ def fractional_transfer(
 
 def random_transfer(
     winner: Candidate,
-    fpv: float,
+    fpv: Numeric,
     ballots: Union[tuple[RankBallot], list[RankBallot]],
     threshold: int,
     *,
@@ -69,7 +69,7 @@ def random_transfer(
     Args:
         winner (Candidate): Candidate to transfer votes from.
             Candidates can be strings, integers, or mix of both.
-        fpv (float): Number of first place votes for winning candidate.
+        fpv (Numeric): Number of first place votes for winning candidate.
         ballots (Union[tuple[RankBallot], list[RankBallot]]): List of Ballot objects.
         threshold (int): Value required to be elected, used to calculate transfer value.
         rng (random.Random, optional): Standard library random number generator. Pass a seeded

--- a/src/votekit/elections/transfers.py
+++ b/src/votekit/elections/transfers.py
@@ -1,5 +1,6 @@
 import math
 import random
+from fractions import Fraction
 from typing import Optional, Union
 
 from votekit.ballot import RankBallot
@@ -96,10 +97,11 @@ def random_transfer(
             new_ranking = tuple([s for s in new_ranking if len(s) != 0])
 
             if ballot.ranking[0] == frozenset({winner}):
+                unit_weight = Fraction(1) if isinstance(ballot.weight, Fraction) else 1
                 new_ballots = [
                     RankBallot(
                         ranking=new_ranking,
-                        weight=1,
+                        weight=unit_weight,
                         voter_set=ballot.voter_set,
                     )
                 ] * int(ballot.weight)

--- a/src/votekit/graphs/ballot_graph.py
+++ b/src/votekit/graphs/ballot_graph.py
@@ -57,7 +57,7 @@ class BallotGraph(Graph):
 
         if isinstance(source, RankProfile):
             self.profile = source
-            self.num_voters = source.total_ballot_wt
+            self.num_voters = float(source.total_ballot_wt)
             self.num_cands = len(source.candidates)
             self.allow_partial = True
             if len(self.graph.nodes) == 0:
@@ -163,7 +163,7 @@ class BallotGraph(Graph):
             self.profile = profile
 
         if self.num_voters is None:
-            self.num_voters = profile.total_ballot_wt
+            self.num_voters = float(profile.total_ballot_wt)
 
         self.candidates = tuple(profile.candidates)
         ballots = profile.ballots
@@ -185,9 +185,9 @@ class BallotGraph(Graph):
                 ballot_node = self.fix_short_ballot(ballot_node, list(self.cand_num.values()))
 
             if tuple(ballot_node) in self.graph.nodes:
-                self.graph.nodes[tuple(ballot_node)]["weight"] += ballot.weight
+                self.graph.nodes[tuple(ballot_node)]["weight"] += float(ballot.weight)
                 self.graph.nodes[tuple(ballot_node)]["cast"] = True
-                self.node_weights[tuple(ballot_node)] += ballot.weight
+                self.node_weights[tuple(ballot_node)] += float(ballot.weight)
 
         return self.graph
 

--- a/src/votekit/matrices/candidate/boost.py
+++ b/src/votekit/matrices/candidate/boost.py
@@ -29,18 +29,18 @@ def boost_prob(i: str, j: str, pref_profile: RankProfile) -> Tuple[float, float]
 
     for ballot in pref_profile.ballots:
         if comention(i, ballot):
-            i_mentions += ballot.weight
+            i_mentions += float(ballot.weight)
 
         if comention(j, ballot):
-            j_mentions += ballot.weight
+            j_mentions += float(ballot.weight)
 
         if comention([i, j], ballot):
-            both_mentions += ballot.weight
+            both_mentions += float(ballot.weight)
 
     return (
-        float(both_mentions) / j_mentions if (j_mentions != 0) else np.nan,
+        both_mentions / j_mentions if (j_mentions != 0) else np.nan,
         (
-            float(i_mentions) / pref_profile.total_ballot_wt
+            i_mentions / float(pref_profile.total_ballot_wt)
             if (pref_profile.total_ballot_wt != 0)
             else np.nan
         ),

--- a/src/votekit/models.py
+++ b/src/votekit/models.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from votekit.elections.election_state import ElectionState
 from votekit.pref_profile.pref_profile import PreferenceProfile
-from votekit.types import Candidate
+from votekit.types import Candidate, CandidateNumericDict
 from votekit.utils import (
     score_dict_to_ranking,
 )
@@ -19,7 +19,7 @@ class Election(Generic[P]):
 
     Args:
         profile (PreferenceProfile): The initial profile of ballots.
-        score_function (Callable[[PreferenceProfile], dict[Candidate, float]], optional):
+        score_function (Callable[[PreferenceProfile], CandidateNumericDict], optional):
             A function that converts profiles to a score dictionary mapping candidates to
             their current score. Used in creating ElectionState objects and sorting candidates in
             Round 0. If None, no score dictionary is saved and all candidates are tied in Round 0.
@@ -31,7 +31,7 @@ class Election(Generic[P]):
         election_states (list[ElectionState]): A list of election states, one for each round of
             the election. The list is 0 indexed, so the initial state is stored at index 0, round 1
             at 1, etc.
-        score_function (Callable[[PreferenceProfile], dict[Candidate, float]], optional):
+        score_function (Callable[[PreferenceProfile], CandidateNumericDict], optional):
             A function that converts profiles to a score dictionary mapping candidates to
             their current score. Used in creating ElectionState objects. Defaults to None.
             Candidates can be strings, integers, or mix of both.
@@ -41,7 +41,7 @@ class Election(Generic[P]):
     def __init__(
         self,
         profile: P,
-        score_function: Optional[Callable[[P], dict[Candidate, float]]] = None,
+        score_function: Optional[Callable[[P], CandidateNumericDict]] = None,
         sort_high_low: bool = True,
     ):
         self._validate_params_and_profile(profile)

--- a/src/votekit/pref_profile/pref_profile.py
+++ b/src/votekit/pref_profile/pref_profile.py
@@ -6,6 +6,7 @@ import os
 import pickle
 import urllib.request
 import warnings
+from fractions import Fraction
 from functools import cached_property
 from os import PathLike
 from pathlib import Path
@@ -30,7 +31,7 @@ from votekit.pref_profile.utils import (
     convert_row_to_rank_ballot,
     convert_row_to_score_ballot,
 )
-from votekit.types import Candidate
+from votekit.types import Candidate, Numeric
 from votekit.utils import _validate_candidate_names, sort_candidates_pseudo_lexicographically
 
 
@@ -68,7 +69,7 @@ class PreferenceProfile:
         candidates_cast (tuple[Candidate]): Tuple of candidates who appear on any ballot with
             positive weight, either in the ranking or in the score dictionary.
             Candidates can be strings, integers, or mix of both.
-        total_ballot_wt (float): Sum of ballot weights.
+        total_ballot_wt (Numeric): Sum of ballot weights.
         num_ballots (int): Length of ballot list.
         contains_rankings (bool): Whether or not the profile contains ballots with
             rankings.
@@ -196,12 +197,12 @@ class PreferenceProfile:
         """
         return len(self._df)
 
-    def _find_total_ballot_wt(self) -> float:
+    def _find_total_ballot_wt(self) -> Numeric:
         """
         Compute and set the total ballot weight.
 
         Returns:
-            float: total ballot weight.
+            Numeric: total ballot weight.
         """
         total_weight = 0
 
@@ -999,6 +1000,12 @@ class RankProfile(PreferenceProfile):
 
         if len(self.ballots) == 0:
             raise ProfileError("Cannot write a profile with no ballots to a csv.")
+
+        if any(isinstance(weight, Fraction) for weight in self._df["Weight"]):
+            raise ValueError(
+                "RankProfile CSV does not support rational weights. Convert a copied profile "
+                "to float first if a lossy export is acceptable."
+            )
 
         candidate_mapping = {c: str(i) for i, c in enumerate(self.candidates)}
 

--- a/src/votekit/pref_profile/utils.py
+++ b/src/votekit/pref_profile/utils.py
@@ -147,14 +147,14 @@ def rank_profile_to_ballot_dict(
         dict[Ballot, float]:
             A dictionary with ballots (keys) and corresponding total weights (values).
     """
-    tot_weight = rank_profile.total_ballot_wt
+    tot_weight = float(rank_profile.total_ballot_wt)
     di: dict = {}
     for ballot in rank_profile.ballots:
         weightless_ballot = Ballot(
             ranking=ballot.ranking,
             voter_set=ballot.voter_set,
         )
-        weight = ballot.weight
+        weight = float(ballot.weight)
         if standardize:
             weight /= tot_weight
 
@@ -181,7 +181,7 @@ def score_profile_to_ballot_dict(
         dict[Ballot, float]:
             A dictionary with ballots (keys) and corresponding total weights (values).
     """
-    tot_weight = score_profile.total_ballot_wt
+    tot_weight = float(score_profile.total_ballot_wt)
     di: dict = {}
     for ballot in score_profile.ballots:
         weightless_ballot = Ballot(
@@ -223,11 +223,11 @@ def rank_profile_to_ranking_dict(
 
     if not isinstance(rank_profile, RankProfile):
         raise TypeError(("Profile must be a RankProfile."))
-    tot_weight = rank_profile.total_ballot_wt
+    tot_weight = float(rank_profile.total_ballot_wt)
     di: dict = {}
     for ballot in rank_profile.ballots:
         ranking = ballot.ranking
-        weight = ballot.weight
+        weight = float(ballot.weight)
         if standardize:
             weight /= tot_weight
         di[ranking] = di.get(ranking, 0) + weight
@@ -260,11 +260,11 @@ def score_profile_to_scores_dict(
     if not isinstance(score_profile, ScoreProfile):
         raise TypeError(("Profile must be a ScoreProfile."))
 
-    tot_weight = score_profile.total_ballot_wt
+    tot_weight = float(score_profile.total_ballot_wt)
     di: dict[tuple[tuple[Candidate, float], ...] | None, float] = {}
     for ballot in score_profile.ballots:
         scores = tuple(ballot.scores.items()) if ballot.scores else None
-        weight = ballot.weight
+        weight = float(ballot.weight)
         if standardize:
             weight /= tot_weight
 
@@ -427,7 +427,7 @@ def convert_rank_profile_to_score_profile_via_score_vector(
     new_df = pd.DataFrame(cand_to_score_list)
     new_df.index.name = "Ballot Index"
     new_df["Voter Set"] = rank_profile.df["Voter Set"]
-    new_df["Weight"] = rank_profile.df["Weight"]
+    new_df["Weight"] = rank_profile.df["Weight"].map(float)
 
     return ScoreProfile(
         df=new_df,

--- a/src/votekit/representation_scores.py
+++ b/src/votekit/representation_scores.py
@@ -53,7 +53,7 @@ def r_representation_score(
             cand_found = False
             for c in s:
                 if c in candidate_list:
-                    satisfied_voters += ballot.weight
+                    satisfied_voters += float(ballot.weight)
                     cand_found = True
                     break
             if cand_found:

--- a/src/votekit/types.py
+++ b/src/votekit/types.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 from typing import Iterable, Mapping, Optional, Sequence, TypeAlias
 
 # ---------------------------------------------------------------------------
@@ -5,6 +6,16 @@ from typing import Iterable, Mapping, Optional, Sequence, TypeAlias
 # ---------------------------------------------------------------------------
 Candidate: TypeAlias = str | int
 CandidateFloatDict: TypeAlias = dict[Candidate, float] | dict[str, float] | dict[int, float]
+Numeric: TypeAlias = float | Fraction
+CandidateNumericDict: TypeAlias = (
+    CandidateFloatDict
+    | dict[Candidate, int]
+    | dict[str, int]
+    | dict[int, int]
+    | dict[Candidate, Fraction]
+    | dict[str, Fraction]
+    | dict[int, Fraction]
+)
 CandidateList: TypeAlias = list[Candidate] | list[str] | list[int]
 
 # ---------------------------------------------------------------------------

--- a/src/votekit/utils/common_utils.py
+++ b/src/votekit/utils/common_utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from votekit.ballot import RankBallot
     from votekit.pref_profile import RankProfile, ScoreProfile
 
-from votekit.types import Candidate, CandidateFloatDict
+from votekit.types import Candidate, CandidateNumericDict, Numeric
 
 COLOR_LIST = [
     "#0099cd",
@@ -96,7 +96,7 @@ def ballots_by_first_cand(profile: RankProfile) -> dict[Candidate, list[RankBall
             ballot_str = str(
                 RankBallot(
                     ranking=tuple(c_set for c_set in row if c_set != tilde),
-                    weight=float(w),
+                    weight=w,
                 )
             )
             raise ValueError(f"Ballot {ballot_str} has a tie for first.")
@@ -108,9 +108,7 @@ def ballots_by_first_cand(profile: RankProfile) -> dict[Candidate, list[RankBall
 
         clean_ranking = tuple(s for s in row if s != tilde)
 
-        cand_dict[cand].append(
-            RankBallot(ranking=clean_ranking, weight=float(w), voter_set=voter_set)
-        )
+        cand_dict[cand].append(RankBallot(ranking=clean_ranking, weight=w, voter_set=voter_set))
 
     return cand_dict
 
@@ -414,7 +412,7 @@ def mentions(
         else:
             for s in ballot.ranking:
                 for cand in s:
-                    mentions[cand] += ballot.weight
+                    mentions[cand] += float(ballot.weight)
     return mentions
 
 
@@ -601,14 +599,14 @@ def tiebroken_ranking(
 
 
 def score_dict_to_ranking(
-    score_dict: CandidateFloatDict,
+    score_dict: CandidateNumericDict,
     sort_high_low: bool = True,
 ) -> tuple[frozenset[Candidate], ...]:
     """
     Sorts candidates into a tuple of frozensets ranking based on a scoring dictionary.
 
     Args:
-        score_dict (dict[Candidate, float] | dict[str, float] | dict[int, float]):
+        score_dict (CandidateNumericDict):
             Dictionary between candidates and their score.
             Candidates can be strings, integers, or mix of both.
         sort_high_low (bool, optional): How to sort candidates based on scores. True sorts
@@ -620,7 +618,7 @@ def score_dict_to_ranking(
             Candidates can be strings, integers, or mix of both.
     """
 
-    score_to_cand: dict[float, list[Candidate]] = {s: [] for s in score_dict.values()}
+    score_to_cand: dict[Numeric, list[Candidate]] = {s: [] for s in score_dict.values()}
     for c, score in score_dict.items():
         score_to_cand[score].append(c)
 
@@ -743,7 +741,7 @@ def expand_tied_ballot(ballot: RankBallot) -> list[RankBallot]:
             if len(s) > 1:
                 new_ballots = [
                     RankBallot(
-                        weight=ballot.weight / math.factorial(len(s)),
+                        weight=float(ballot.weight) / math.factorial(len(s)),
                         voter_set=ballot.voter_set,
                         ranking=tuple(ballot.ranking[:i])
                         + tuple([frozenset({c}) for c in order])
@@ -834,7 +832,7 @@ def ballot_lengths(profile: RankProfile) -> dict[int, float]:
             raise TypeError("All ballots must have rankings.")
 
         length = len(ballot.ranking)
-        ballot_lengths[length] += ballot.weight
+        ballot_lengths[length] += float(ballot.weight)
 
     return ballot_lengths
 

--- a/tests/ballot/test_RankBallot.py
+++ b/tests/ballot/test_RankBallot.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import pytest
 
 from votekit.ballot import Ballot, RankBallot
@@ -66,6 +68,22 @@ def test_ballot_hash():
 def test_ballot_coerce_wt_to_float():
     assert isinstance(RankBallot(weight=3).weight, float)
     assert isinstance(RankBallot(weight=3.2).weight, float)
+
+
+def test_ballot_preserves_fraction_weight():
+    weight = Fraction(1, 3)
+    ballot = RankBallot(ranking=({"A"},), weight=weight)
+    rational_half = RankBallot(ranking=({"A"},), weight=Fraction(1, 2))
+    float_half = RankBallot(ranking=({"A"},), weight=0.5)
+
+    assert ballot.weight is weight
+    assert rational_half == float_half
+    assert hash(rational_half) == hash(float_half)
+
+
+def test_ballot_rejects_negative_fraction_weight():
+    with pytest.raises(ValueError, match="Ballot weight cannot be negative"):
+        RankBallot(ranking=({"A"},), weight=Fraction(-1, 3))
 
 
 def test_ballot_strip_whitespace():

--- a/tests/ballot/test_ScoreBallot.py
+++ b/tests/ballot/test_ScoreBallot.py
@@ -1,3 +1,6 @@
+from fractions import Fraction
+from typing import Any, cast
+
 import pytest
 
 from votekit.ballot import Ballot, ScoreBallot
@@ -64,6 +67,13 @@ def test_ballot_hash():
 def test_ballot_coerce_wt_to_float():
     assert isinstance(ScoreBallot(weight=3).weight, float)
     assert isinstance(ScoreBallot(weight=3.2).weight, float)
+
+
+def test_ballot_coerces_out_of_contract_fraction_weight_to_float():
+    ballot = ScoreBallot(weight=cast(Any, Fraction(1, 3)))
+
+    assert isinstance(ballot.weight, float)
+    assert ballot.weight == float(Fraction(1, 3))
 
 
 def test_ballot_strip_whitespace():

--- a/tests/ballot_generators/bloc_slate_generators/test_cambridge.py
+++ b/tests/ballot_generators/bloc_slate_generators/test_cambridge.py
@@ -318,11 +318,11 @@ def test_two_bloc_two_slate_cambridge_distribution_matches_name_ballot_dist(
             )
 
             obs_prob = float(
-                (
+                float(
                     comparisons_profile[(f"{slate}1", f"{slate}2")]
                     + comparisons_profile[(f"{slate}1",)]
                 )
-                / (profile.total_ballot_wt - comparisons_profile[()])
+                / (float(profile.total_ballot_wt) - comparisons_profile[()])
             )
             exp_prob = float(
                 config.preference_df.loc[bloc][f"{slate}1"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def do_ballot_probs_match_ballot_dist_rank_profile():
                 failed += 1
 
         # allow for small margin of error given confidence intereval
-        failure_thresold = round((1 - alpha) * n_ballots)
+        failure_thresold = round((1 - alpha) * float(n_ballots))
         return failed <= failure_thresold
 
     return _do_ballot_probs_match_ballot_dist_rank_profile
@@ -212,7 +212,7 @@ def do_ballot_probs_match_ballot_dist_score_profile():
                 failed += 1
 
         # allow for small margin of error given confidence intereval
-        failure_thresold = round((1 - alpha) * n_ballots)
+        failure_thresold = round((1 - alpha) * float(n_ballots))
         return failed <= failure_thresold
 
     return _do_ballot_probs_match_ballot_dist_score_profile

--- a/tests/elections/election_types/ranking/test_stv.py
+++ b/tests/elections/election_types/ranking/test_stv.py
@@ -532,7 +532,14 @@ def test_stv_rounding_errors():
     stv_election = STV(profile=profile, n_seats=5)
     assert stv_election.get_elected() == ({"A1"}, {"A2"}, {"A3"}, {"A4"}, {"B1"})
 
-    assert [stv_election.election_states[i].scores[f"A{i + 1}"] for i in range(5)] == [
+    assert [
+        next(
+            score
+            for candidate, score in stv_election.election_states[i].scores.items()
+            if candidate == f"A{i + 1}"
+        )
+        for i in range(5)
+    ] == [
         52,
         41,
         30,

--- a/tests/elections/election_types/ranking/test_stv_exact.py
+++ b/tests/elections/election_types/ranking/test_stv_exact.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from votekit.ballot import RankBallot
-from votekit.elections import IRV, STV, SequentialRCV, fractional_transfer
+from votekit.elections import IRV, STV, SequentialRCV, fractional_transfer, random_transfer
 from votekit.graphs.ballot_graph import BallotGraph
 from votekit.pref_profile import RankProfile
 from votekit.pref_profile.utils import (
@@ -363,6 +363,29 @@ def test_exact_stv_accepts_custom_fraction_preserving_transfer():
         isinstance(score, Fraction)
         for state in election.election_states
         for score in state.scores.values()
+    )
+
+
+def test_exact_stv_random_transfer_preserves_fraction_weights():
+    profile = _three_candidate_profile(Fraction(3), Fraction(1), Fraction(1))
+
+    election = STV(
+        profile,
+        n_seats=2,
+        exact=True,
+        transfer=random_transfer,
+        rng_seed=1,
+    )
+
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+    assert all(
+        isinstance(ballot.weight, Fraction)
+        for round_number in range(len(election.election_states))
+        for ballot in election.get_profile(round_number).ballots
     )
 
 

--- a/tests/elections/election_types/ranking/test_stv_exact.py
+++ b/tests/elections/election_types/ranking/test_stv_exact.py
@@ -1,0 +1,435 @@
+import pickle
+from fractions import Fraction
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from votekit.ballot import RankBallot
+from votekit.elections import IRV, STV, SequentialRCV, fractional_transfer
+from votekit.graphs.ballot_graph import BallotGraph
+from votekit.pref_profile import RankProfile
+from votekit.pref_profile.utils import (
+    convert_rank_profile_to_score_profile_via_score_vector,
+    rank_profile_to_ballot_dict,
+    rank_profile_to_ranking_dict,
+)
+from votekit.utils import ballot_lengths, mentions
+
+
+def _three_candidate_profile(*weights: object) -> RankProfile:
+    if not weights:
+        weights = (3, 2, 1)
+    rankings = (({"A"}, {"B"}, {"C"}), ({"B"}, {"C"}, {"A"}), ({"C"}, {"A"}, {"B"}))
+    return RankProfile(
+        ballots=tuple(
+            RankBallot(ranking=ranking, weight=cast(Any, weight))
+            for ranking, weight in zip(rankings, weights)
+        )
+    )
+
+
+def _score_for(election: STV, round_number: int, candidate: str):
+    return next(
+        score
+        for scored_candidate, score in election.election_states[round_number].scores.items()
+        if scored_candidate == candidate
+    )
+
+
+def test_exact_stv_preserves_rationals_through_states_and_replay():
+    profile = _three_candidate_profile(Fraction(7, 3), Fraction(5, 3), Fraction(1))
+    election = STV(profile, n_seats=2, exact=True, rng_seed=2)
+
+    assert all(isinstance(ballot.weight, Fraction) for ballot in profile.ballots)
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+    for round_number in range(len(election.election_states)):
+        replayed_profile, state = election.get_step(round_number)
+        assert state == election.election_states[round_number]
+        assert all(isinstance(ballot.weight, Fraction) for ballot in replayed_profile.ballots)
+
+
+def test_exact_stv_does_not_mutate_float_input_profile():
+    profile = _three_candidate_profile(3, 2, 1)
+    STV(profile, n_seats=2, exact=True, rng_seed=2)
+
+    assert all(isinstance(ballot.weight, float) for ballot in profile.ballots)
+
+
+@pytest.mark.parametrize("value", [1, 1.0, np.int64(1), np.float64(1.0)])
+def test_exact_stv_converts_integral_real_weights(value: object):
+    profile = _three_candidate_profile()
+    df = profile.df.copy()
+    df["Weight"] = pd.Series([value, 2, 1], dtype=object)
+    converted = RankProfile(
+        df=df,
+        candidates=profile.candidates,
+        max_ranking_length=profile.max_ranking_length,
+    )
+
+    election = STV(converted, n_seats=2, exact=True, rng_seed=2)
+
+    assert all(isinstance(ballot.weight, Fraction) for ballot in election.get_profile(0).ballots)
+
+
+def test_exact_stv_rejects_non_integral_float_weight():
+    profile = _three_candidate_profile()
+    df = profile.df.copy()
+    df["Weight"] = pd.Series([1.5, 2, 1], dtype=object)
+    invalid = RankProfile(
+        df=df,
+        candidates=profile.candidates,
+        max_ranking_length=profile.max_ranking_length,
+    )
+
+    with pytest.raises(ValueError, match=r"pass Fraction\(numerator, denominator\)"):
+        STV(invalid, n_seats=2, exact=True)
+
+
+def test_exact_stv_rejects_non_integral_longdouble_without_narrowing():
+    weight = np.longdouble(2**53) + np.longdouble("0.5")
+    if weight == int(weight):
+        return
+
+    profile = _three_candidate_profile()
+    df = profile.df.copy()
+    df["Weight"] = pd.Series([weight, 2, 1], dtype=object)
+    invalid = RankProfile(
+        df=df,
+        candidates=profile.candidates,
+        max_ranking_length=profile.max_ranking_length,
+    )
+
+    with pytest.raises(ValueError, match=r"pass Fraction\(numerator, denominator\)"):
+        STV(invalid, n_seats=2, exact=True)
+
+
+@pytest.mark.parametrize("weight", [-1, Fraction(-1, 3)])
+def test_exact_stv_rejects_negative_dataframe_weight(weight: object):
+    profile = _three_candidate_profile()
+    df = profile.df.copy()
+    df["Weight"] = pd.Series([weight, 2, 1], dtype=object)
+    invalid = RankProfile(
+        df=df,
+        candidates=profile.candidates,
+        max_ranking_length=profile.max_ranking_length,
+    )
+
+    with pytest.raises(ValueError, match="Ballot weight cannot be negative"):
+        STV(invalid, n_seats=2, exact=True)
+
+
+@pytest.mark.parametrize(
+    ("quota", "total", "expected"),
+    [
+        ("droop", 2**53 + 1, (2**53 + 1) // 3 + 1),
+        ("hare", 2**53 + 3, (2**53 + 3) // 2),
+    ],
+)
+def test_exact_stv_large_threshold_uses_exact_total(quota: str, total: int, expected: int):
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(total - 1)),
+            RankBallot(ranking=({"B"}, {"A"}), weight=Fraction(1)),
+        )
+    )
+
+    election = STV(profile, n_seats=2, quota=cast(Any, quota), exact=True)
+
+    assert election.threshold == expected
+
+
+def test_default_stv_converts_rational_profile_to_float_path():
+    weights = (3002399751580327, 3002399751580331, 3002399751580335)
+    rational_profile = _three_candidate_profile(*(Fraction(weight) for weight in weights))
+    float_profile = _three_candidate_profile(*(float(weight) for weight in weights))
+
+    rational_election = STV(
+        rational_profile,
+        n_seats=2,
+        simultaneous=False,
+        tiebreak="random",
+        rng_seed=1,
+    )
+    float_election = STV(
+        float_profile,
+        n_seats=2,
+        simultaneous=False,
+        tiebreak="random",
+        rng_seed=1,
+    )
+
+    assert rational_election.threshold == float_election.threshold == 3002399751580331
+    assert rational_election.get_elected() == float_election.get_elected()
+    assert all(
+        isinstance(ballot.weight, float) for ballot in rational_election.get_profile(0).ballots
+    )
+
+
+def test_exact_stv_rejects_zero_hare_quota():
+    profile = RankProfile(ballots=(RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(1, 3)),))
+
+    with pytest.raises(ValueError, match="positive Hare quota"):
+        STV(profile, n_seats=2, quota="hare", exact=True)
+
+
+def test_default_stv_preserves_zero_hare_quota_behavior():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=(1, 2, 0), weight=2 / 15),
+            RankBallot(ranking=(0, 1, 2), weight=8 / 15),
+            RankBallot(ranking=(2, 1, 0), weight=5 / 15),
+        )
+    )
+
+    election = STV(
+        profile,
+        n_seats=2,
+        quota="hare",
+        simultaneous=False,
+        tiebreak="random",
+        rng_seed=6,
+    )
+
+    assert election.threshold == 0
+    assert election.get_elected() == ({0}, {1})
+
+
+def test_exact_stv_keeps_zero_first_place_candidate_and_terminal_state():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(3)),
+            RankBallot(ranking=({"C"}, {"B"}, {"A"}), weight=Fraction(1)),
+        )
+    )
+    election = STV(profile, n_seats=2, exact=True, rng_seed=3)
+
+    assert _score_for(election, 0, "B") == Fraction(0)
+    assert election.election_states[-1].scores == {}
+    assert election.get_profile(-1).ballots == ()
+
+
+def test_exact_stv_tallies_and_tie_are_exact():
+    # Pullled from issue #311
+    ballot_a = RankBallot(ranking=[{f"A{i + 1}"} for i in range(5)])
+    ballot_b = RankBallot(ranking=({"B1"},))
+    profile = RankProfile(ballots=[ballot_a] * 52 + [ballot_b] * 8)
+
+    election = STV(profile, n_seats=5, exact=True)
+
+    assert [_score_for(election, i, f"A{i + 1}") for i in range(5)] == [
+        Fraction(52),
+        Fraction(41),
+        Fraction(30),
+        Fraction(19),
+        Fraction(8),
+    ]
+    assert _score_for(election, 4, "A5") == _score_for(election, 4, "B1")
+    assert election.get_elected() == ({"A1"}, {"A2"}, {"A3"}, {"A4"}, {"B1"})
+
+
+def test_exact_stv_distinguishes_scores_below_float_resolution():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(2**54 + 1)),
+            RankBallot(ranking=({"B"}, {"A"}), weight=Fraction(2**54)),
+        )
+    )
+
+    election = STV(profile, exact=True)
+
+    assert _score_for(election, 0, "A") > _score_for(election, 0, "B")
+    assert float(_score_for(election, 0, "A")) == float(_score_for(election, 0, "B"))
+
+
+def test_exact_stv_records_seeded_loser_tie_for_replay():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(2)),
+            RankBallot(ranking=({"B"}, {"A"}, {"C"}), weight=Fraction(1)),
+            RankBallot(ranking=({"C"}, {"A"}, {"B"}), weight=Fraction(1)),
+        )
+    )
+    election = STV(profile, exact=True, rng_seed=358)
+    recorded_order = tuple(state.eliminated for state in election.election_states)
+    rng_state = election._rng.getstate()
+
+    for round_number in range(len(election.election_states)):
+        election.get_step(round_number)
+
+    assert election._rng.getstate() == rng_state
+    assert tuple(state.eliminated for state in election.election_states) == recorded_order
+    assert any(state.tiebreaks for state in election.election_states)
+
+
+@pytest.mark.parametrize("tiebreak", ["alphabetical", "lexicographic", "alph", "lex"])
+def test_exact_stv_accepts_lexicographic_tiebreak_aliases(tiebreak: str):
+    election = STV(
+        _three_candidate_profile(),
+        n_seats=2,
+        exact=True,
+        tiebreak=cast(Any, tiebreak),
+        rng_seed=2,
+    )
+
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+
+
+def test_exact_stv_uses_exact_borda_tiebreak():
+    large_weight = 2**54
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"C"}, {"B"}), weight=Fraction(large_weight)),
+            RankBallot(ranking=({"B"}, {"C"}, {"A"}), weight=Fraction(large_weight)),
+            RankBallot(ranking=({"A"}, {"B"}, {"C"}), weight=Fraction(1)),
+            RankBallot(ranking=({"B"}, {"C"}, {"A"}), weight=Fraction(1)),
+        )
+    )
+
+    election = STV(
+        profile,
+        n_seats=2,
+        simultaneous=False,
+        exact=True,
+        tiebreak="borda",
+    )
+
+    resolution = next(
+        resolved
+        for state in election.election_states
+        for tied, resolved in state.tiebreaks.items()
+        if tied == frozenset({"A", "B"})
+    )
+    assert resolution[0] == frozenset({"B"})
+
+
+def test_exact_stv_accepts_first_place_tiebreak():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"C"}, {"B"})),
+            RankBallot(ranking=({"B"}, {"A"}, {"C"})),
+        )
+    )
+
+    election = STV(
+        profile,
+        n_seats=2,
+        simultaneous=False,
+        exact=True,
+        tiebreak="first_place",
+        rng_seed=358,
+    )
+
+    assert any(
+        tied == frozenset({"A", "B"})
+        for state in election.election_states
+        for tied in state.tiebreaks
+    )
+
+
+def test_exact_stv_rejects_invalid_tiebreak():
+    with pytest.raises(ValueError, match="supports only"):
+        STV(
+            _three_candidate_profile(),
+            n_seats=2,
+            exact=True,
+            tiebreak=cast(Any, "invalid"),
+        )
+
+
+def test_exact_stv_accepts_custom_fraction_preserving_transfer():
+    profile = _three_candidate_profile()
+    calls = []
+
+    def custom_transfer(winner, fpv, ballots, threshold):
+        calls.append((winner, fpv))
+        assert isinstance(fpv, Fraction)
+        assert all(isinstance(ballot.weight, Fraction) for ballot in ballots)
+        return fractional_transfer(winner, fpv, ballots, threshold)
+
+    election = STV(profile, n_seats=2, exact=True, transfer=custom_transfer)
+
+    assert calls
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+
+
+def test_exact_irv_preserves_fraction_weights_and_scores():
+    profile = _three_candidate_profile(Fraction(7, 3), Fraction(5, 3), Fraction(1))
+
+    election = IRV(profile, exact=True)
+
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+    assert all(
+        isinstance(ballot.weight, Fraction)
+        for round_number in range(len(election.election_states))
+        for ballot in election.get_profile(round_number).ballots
+    )
+
+
+def test_exact_sequential_rcv_preserves_fraction_weights_and_scores():
+    profile = _three_candidate_profile(Fraction(7, 3), Fraction(5, 3), Fraction(1))
+
+    election = SequentialRCV(profile, n_seats=2, exact=True)
+
+    assert all(
+        isinstance(score, Fraction)
+        for state in election.election_states
+        for score in state.scores.values()
+    )
+    assert all(
+        isinstance(ballot.weight, Fraction)
+        for round_number in range(len(election.election_states))
+        for ballot in election.get_profile(round_number).ballots
+    )
+
+
+def test_exact_profile_pickle_csv_and_state_dict_boundaries(tmp_path):
+    profile = _three_candidate_profile(Fraction(7, 3), Fraction(5, 3), Fraction(1))
+    restored = pickle.loads(pickle.dumps(profile))
+    election = STV(profile, n_seats=2, exact=True, rng_seed=2)
+
+    assert all(isinstance(ballot.weight, Fraction) for ballot in restored.ballots)
+    assert all(
+        isinstance(value, Fraction)
+        for value in election.election_states[0].to_dict()["scores"].values()
+    )
+    with pytest.raises(ValueError, match="does not support rational weights"):
+        profile.to_csv(tmp_path / "exact.csv")
+
+
+def test_shared_rational_profile_float_boundaries():
+    profile = RankProfile(ballots=(RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(1, 3)),))
+
+    values = (
+        *rank_profile_to_ballot_dict(profile, standardize=True).values(),
+        *rank_profile_to_ranking_dict(profile).values(),
+        *rank_profile_to_ranking_dict(profile, standardize=True).values(),
+        *mentions(profile).values(),
+        *ballot_lengths(profile).values(),
+    )
+    score_profile = convert_rank_profile_to_score_profile_via_score_vector(profile, [1, 0])
+    graph = BallotGraph(profile)
+
+    assert all(isinstance(value, float) for value in values)
+    assert all(isinstance(weight, float) for weight in score_profile._df["Weight"])
+    assert isinstance(score_profile.total_ballot_wt, float)
+    assert all(isinstance(ballot.weight, float) for ballot in score_profile.ballots)
+    assert isinstance(graph.num_voters, float)
+    assert all(isinstance(weight, float) for weight in graph.node_weights.values() if weight)

--- a/tests/elections/test_transfers.py
+++ b/tests/elections/test_transfers.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import pytest
 
 from votekit.ballot import RankBallot
@@ -30,6 +32,18 @@ def test_fractional_transfer():
             RankBallot(ranking=({"C"}, {"B"}), weight=1),
         )
     )
+
+
+def test_fractional_transfer_preserves_large_rational_weight():
+    denominator = 2**80 + 7
+    ballot = RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(2**90 + 3, denominator))
+    fpv = ballot.weight
+
+    transferred = fractional_transfer("A", fpv, [ballot], 1)
+
+    expected = ballot.weight * (fpv - 1) / fpv
+    assert transferred[0].weight == expected
+    assert isinstance(transferred[0].weight, Fraction)
 
 
 def test_fractional_transfer_error():

--- a/tests/test_animations.py
+++ b/tests/test_animations.py
@@ -1,6 +1,8 @@
 import shutil
 import subprocess
 import warnings
+from collections.abc import Mapping
+from fractions import Fraction
 from pathlib import Path
 from typing import Literal, Optional, cast
 
@@ -101,6 +103,32 @@ def test_STVAnimation_init(election_happy):
     assert isinstance(animation.events, list)
     assert "Pear" in animation.candidate_dict.keys()
     assert animation.candidate_dict["Pear"]["support"] == 8
+
+
+def test_STVAnimation_exact_values_cross_float_boundary():
+    profile = RankProfile(
+        ballots=(
+            RankBallot(ranking=({"A"}, {"B"}), weight=Fraction(4, 3)),
+            RankBallot(ranking=({"B"}, {"A"}), weight=Fraction(1, 3)),
+        )
+    )
+    animation = STVAnimation(STV(profile, exact=True), focus="all")
+
+    def leaf_values(mapping):
+        for value in mapping.values():
+            if isinstance(value, Mapping):
+                yield from leaf_values(value)
+            else:
+                yield value
+
+    assert all(
+        isinstance(candidate["support"], float) for candidate in animation.candidate_dict.values()
+    )
+    assert all(
+        isinstance(value, float)
+        for event in animation.events
+        for value in leaf_values(getattr(event, "support_transferred", {}))
+    )
 
 
 def test_STVAnimation_focus_bad_literal(election_happy):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -198,7 +198,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -758,17 +758,17 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -788,16 +788,16 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -1601,7 +1601,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1948,7 +1948,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Restores Fraction ballot-weight support and adds opt-in exact arithmetic to STV, IRV, and Sequential RCV elections.

### Additional Notes

- Support for other classes and election methods is planned in the future. 
- CSV storage through `to_csv` with fractionally-weighted profiles not supported at this time (planned).
- Revisits #311

## Why

Converting rational weights to floats can lose precision, especially for large or closely spaced values. That precision loss can change quotas, candidate rankings, tiebreaks, and election results.

Exact mode preserves rational arithmetic when correctness is more important than the performance of the existing float path. Float arithmetic remains the default for compatibility and speed.


## Changes

- Preserve Fraction weights through ballots, profiles, election states, profile replay, and fractional transfers.
- Add exact=True to STV, IRV, and Sequential RCV for exact tallies, thresholds, and tiebreak scores.
- Add exact-arithmetic helpers and coverage for large values, transfers, replay, tiebreaks, and serialization boundaries.

## Testing

- [x] Relevant checks pass locally
- [x] Tests were added or updated for behavior changes
- [x] Documentation was updated for public API or user-facing changes


## Reviewer Notes

- Exact arithmetic is opt-in. Existing elections continue using the float path by default.
- IRV and Sequential RCV do not perform fractional surplus reweighting, but exact mode still preserves their rational tallies, thresholds, and tiebreak scores.
- Non-integral float weights are rejected in exact mode because their intended rational value is ambiguous.
- NumPy-backed fast election implementations remain on their existing float path.
- Most sensitive file in this PR is `stv.py`. Most other changes are argument threading / type fixes.
