### PR TITLE
De-fragment group_ballots so wide profiles stop emitting pandas PerformanceWarning

### DIFF
--- a/src/votekit/pref_profile/pref_profile.py
+++ b/src/votekit/pref_profile/pref_profile.py
@@ -26,6 +26,7 @@ from votekit.pref_profile.csv_utils import (
     _validate_score_csv_format,
 )
 from votekit.pref_profile.utils import (
+    _move_group_keys_to_columns,
     _sum_rank_profiles,
     _sum_score_profiles,
     convert_row_to_rank_ballot,
@@ -818,12 +819,14 @@ class RankProfile(PreferenceProfile):
 
         ranking_cols = [c for c in self.df.columns if "Ranking_" in c]
         group_df = self.df.groupby(ranking_cols, dropna=False)
-        new_df = group_df.aggregate(
-            {
-                "Weight": "sum",
-                "Voter Set": (lambda sets: set().union(*sets)),
-            }
-        ).reset_index()
+        new_df = _move_group_keys_to_columns(
+            group_df.aggregate(
+                {
+                    "Weight": "sum",
+                    "Voter Set": (lambda sets: set().union(*sets)),
+                }
+            )
+        )
 
         new_df.index.name = "Ballot Index"
 
@@ -1487,12 +1490,14 @@ class ScoreProfile(PreferenceProfile):
         cand_cols = [c for c in self.df.columns if c not in non_group_cols]
 
         group_df = self.df.groupby(cand_cols, dropna=False)
-        new_df = group_df.aggregate(
-            {
-                "Weight": "sum",
-                "Voter Set": (lambda sets: set().union(*sets)),
-            }
-        ).reset_index()
+        new_df = _move_group_keys_to_columns(
+            group_df.aggregate(
+                {
+                    "Weight": "sum",
+                    "Voter Set": (lambda sets: set().union(*sets)),
+                }
+            )
+        )
 
         new_df.index.name = "Ballot Index"
 

--- a/src/votekit/pref_profile/utils.py
+++ b/src/votekit/pref_profile/utils.py
@@ -101,6 +101,27 @@ def convert_row_to_score_ballot(row: pd.Series, candidates: tuple[Candidate, ...
     )
 
 
+def _move_group_keys_to_columns(grouped_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Move the group keys of an aggregated, group-indexed df back into columns, placing them
+    ahead of the aggregated columns. Equivalent to ``grouped_df.reset_index()``, but builds
+    the result in a single concatenation.
+
+    Args:
+        grouped_df (pd.DataFrame): Aggregated df indexed by its group keys.
+
+    Returns:
+        pd.DataFrame: Df with the group keys as leading columns and a fresh integer index.
+
+    """
+    # reset_index() inserts one column per group key, so a profile with many ranking or
+    # candidate columns trips pandas' "DataFrame is highly fragmented" PerformanceWarning.
+    return pd.concat(
+        [grouped_df.index.to_frame(index=False), grouped_df.reset_index(drop=True)],
+        axis=1,
+    )
+
+
 def _df_to_rank_ballot_tuple(
     df: pd.DataFrame, candidates: tuple[Candidate, ...], max_ranking_length: int = 0
 ) -> tuple[RankBallot, ...]:

--- a/tests/pref_profile/rank_profile/test_rank_pp_group_ballots.py
+++ b/tests/pref_profile/rank_profile/test_rank_pp_group_ballots.py
@@ -1,3 +1,7 @@
+import warnings
+
+from pandas.errors import PerformanceWarning
+
 from votekit.ballot import RankBallot
 from votekit.pref_profile import RankProfile
 
@@ -26,3 +30,54 @@ def test_pp_group_ballots_ranking():
     )
     assert set(pp.candidates) == set(profile.candidates)
     assert profile == pp
+
+
+def _wide_rank_profile(n_cands: int, n_ballots: int) -> RankProfile:
+    candidates = [f"C{i}" for i in range(n_cands)]
+    ballots = tuple(
+        RankBallot(
+            ranking=tuple({c} for c in candidates[i % n_cands :] + candidates[: i % n_cands]),
+            weight=1,
+        )
+        for i in range(n_ballots)
+    )
+    return RankProfile(ballots=ballots, candidates=tuple(candidates))
+
+
+def test_pp_group_ballots_ranking_no_fragmentation_warning():
+    profile = _wide_rank_profile(120, 300)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        profile.group_ballots()
+
+
+def test_pp_group_ballots_ranking_wide_profile_groups_correctly():
+    profile = _wide_rank_profile(120, 300)
+
+    pp = profile.group_ballots()
+    assert pp.num_ballots == 120
+    assert pp.total_ballot_wt == profile.total_ballot_wt
+    assert set(pp.df.columns) == set(profile.df.columns)
+    assert {b.ranking for b in pp.ballots} == {b.ranking for b in profile.ballots}
+
+    # the i-th ballot ranks rotation i % 120, so 300 ballots give 60 rotations seen 3
+    # times and 60 seen twice
+    weights = sorted(b.weight for b in pp.ballots)
+    assert weights == [2] * 60 + [3] * 60
+    assert profile == pp
+
+
+def test_pp_group_ballots_ranking_no_ranking_ballots():
+    profile = RankProfile(
+        ballots=(RankBallot(weight=1),) * 2,
+        candidates=tuple(f"C{i}" for i in range(120)),
+        max_ranking_length=120,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        pp = profile.group_ballots()
+
+    assert pp.num_ballots == 1
+    assert pp.total_ballot_wt == 2

--- a/tests/pref_profile/score_profile/test_score_pp_group_ballots.py
+++ b/tests/pref_profile/score_profile/test_score_pp_group_ballots.py
@@ -1,3 +1,7 @@
+import warnings
+
+from pandas.errors import PerformanceWarning
+
 from votekit.ballot import ScoreBallot
 from votekit.pref_profile import ScoreProfile
 
@@ -27,4 +31,34 @@ def test_pp_group_ballots_scores():
         )
     )
     assert set(pp.candidates) == set(profile.candidates)
+    assert profile == pp
+
+
+def _wide_score_profile(n_cands: int, n_ballots: int) -> ScoreProfile:
+    candidates = tuple(f"C{i}" for i in range(n_cands))
+    ballots = tuple(
+        ScoreBallot(scores={c: (i % 5) + 1 for c in candidates}, weight=1) for i in range(n_ballots)
+    )
+    return ScoreProfile(ballots=ballots, candidates=candidates)
+
+
+def test_pp_group_ballots_scores_no_fragmentation_warning():
+    profile = _wide_score_profile(120, 300)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        profile.group_ballots()
+
+
+def test_pp_group_ballots_scores_wide_profile_groups_correctly():
+    profile = _wide_score_profile(120, 300)
+
+    pp = profile.group_ballots()
+    assert pp.num_ballots == 5
+    assert pp.total_ballot_wt == profile.total_ballot_wt
+    assert set(pp.ballots) == set(
+        ScoreBallot(scores={c: (i % 5) + 1 for c in profile.candidates}, weight=60)
+        for i in range(5)
+    )
+    assert set(pp.df.columns) == set(profile.df.columns)
     assert profile == pp


### PR DESCRIPTION
This PR proposes de-fragmenting `group_ballots()` so that grouping a profile with many candidates no longer emits pandas' "DataFrame is highly fragmented" `PerformanceWarning` (Fixes #323). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/205. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

`RankProfile.group_ballots()` aggregates over one group key per ranking column and then calls `.reset_index()` on the result. `reset_index()` inserts the group keys back as columns one at a time, so once a profile has enough ranking columns pandas starts warning that the frame is fragmented — the warning that #323 reports coming out of `load_scottish` on large profiles. `ScoreProfile.group_ballots()` has the identical shape (one group key per candidate column) and warns the same way, so both are fixed here.

Reproduced on `main` at 6b25863a:

```python
import warnings
from votekit.ballot import RankBallot
from votekit.pref_profile import RankProfile

cands = [f"C{i}" for i in range(120)]
profile = RankProfile(
    ballots=[
        RankBallot(ranking=[{c} for c in cands[b % 120:] + cands[:b % 120]], weight=1)
        for b in range(300)
    ],
    candidates=cands,
)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    profile.group_ballots()
print(len([x for x in w if "fragmented" in str(x.message)]))
```

On `main` that prints `22`; on this branch it prints `0`. Every one of the 22 is raised from `pref_profile.py:826`, the `.reset_index()` call. Going through the loader the issue names — a generated Scottish CSV with 120 candidates and 300 ballots — `load_scottish()` emits the same 22 warnings on `main` and 0 here, returning the same 121 grouped ballots and 120 candidates either way.

## The change

The aggregated frame's group keys are now moved back into columns in a single concatenation (`index.to_frame(index=False)` concatenated with the aggregated columns) rather than inserted one by one — which is what pandas' own warning text suggests. This is a private helper, `_move_group_keys_to_columns`, in `pref_profile/utils.py`, used by both `group_ballots()` implementations.

The result is the same frame, not merely an equivalent one: I compared the old and new frames with `pandas.testing.assert_frame_equal(..., check_exact=True)` across a wide profile, a single-ranking-column profile, ties plus blank positions, zero-weight ballots, ballots with no ranking, and score profiles with `NaN` groups — column order, dtypes and values match in every case. Public behaviour is untouched, so no existing call site changes.

It is also a bit quicker, since the repeated inserts were the slow part. On the 120-candidate profile above, `group_ballots()` goes from a median of 81 ms to 58 ms over 20 runs on one machine — a side effect of the fix rather than its point.

## Verifying it

`tests/pref_profile/rank_profile/test_rank_pp_group_ballots.py` and `tests/pref_profile/score_profile/test_score_pp_group_ballots.py` gain five tests: two that turn `PerformanceWarning` into an error around `group_ballots()` on a wide rank and a wide score profile, one covering a profile whose ballots have no ranking, and two that pin the grouping result itself on wide profiles (ballot count, total weight, the set of rankings, per-group weights, column set, and profile equality). With the source change reverted and the tests kept, three of the five fail; with it applied all five pass.

Full suite before the change: 1596 passed, 20 skipped, 0 failed. After: 1601 passed, 20 skipped, 0 failed — the five new tests, and an identical (empty) failure set, so nothing regressed. `ruff check` and `ruff format --check` are clean over `src` and `tests`. Both runs used `PYTHONHASHSEED=0 uv run pytest tests --ignore=tests/test_animations.py -n 4`; `test_animations.py` is excluded only because the optional `animation` extra needs a system `cairo` I could not build here, and it is untouched by this change.

One thing I noticed while writing the tests but deliberately left alone: a grouped profile's `df` orders `Weight` and `Voter Set` differently from a profile built directly from ballots. It predates this change and is unrelated to it, so it is not in this diff — mentioning it only in case it is news.

## How this was managed

We imported your issues and pull requests into a Tracker board and worked this fix on the story for #323: https://eastagiletracker.com/projects/205/stories/75679. The board is at https://eastagiletracker.com/projects/205 — 373 stories and 14 labels imported from this repository, with your milestones as epics.

![board](https://raw.githubusercontent.com/eastagiletracker/VoteKit/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
