### PR TITLE
Perturb/Alter Ballots within Profile

### DIFF
--- a/src/votekit/utils/transform_profiles_utils.py
+++ b/src/votekit/utils/transform_profiles_utils.py
@@ -1,0 +1,129 @@
+from typing import Callable, Literal, Sequence
+
+import pandas as pd
+
+from votekit.ballot import RankBallot
+from votekit.pref_profile import RankProfile
+from votekit.types import Candidate
+
+
+def transform_ballots_profile(
+    profile: RankProfile,
+    transform_ballot_func: Callable[[RankBallot | list[Candidate]], RankBallot | list[Candidate]],
+    on: Literal["candidates", "ballot"] = "ballot",
+    group_ballots: bool = True,
+) -> RankProfile:
+    """
+    Applies an user-defined transformation function upon every ballot within a profile.
+
+    Can group ballots to alter by ballot type instead of per ballot. The function can accept
+    list of candidates that represent a ranking or a ballot and must return the same type.
+    If a list of candidates is expected, then the profile cannot contain tied candidates or
+    unexpected behavior will occur. Transformed ballots are not regrouped by ballot type.
+
+    Args:
+        profile (RankProfile): profile to transform.
+        transform_ballot_func (Callable[[RankBallot | list[Candidate]],
+            RankBallot | list[Candidate]]): ballot transform function.
+        on (Literal["candidates', 'ballot']): data type to apply transform function on.
+            RankBallot by default. Can select candidates for list of candidates. Weights and Voter
+            Sets are preserved for list of candidates as well as ballots.
+        group_ballots (bool): Groups ballots with identical rankings and updates the weight
+            accordingly. True by default. Can set to False if ballots are altered in a probalistic
+            or per-ballot manner.
+    Returns:
+        RankProfile: altered rank profile.
+
+    """
+    if not isinstance(profile, RankProfile):
+        raise TypeError("Can only alter ballots from a RankProfile.")
+
+    if group_ballots:
+        profile = profile.group_ballots()
+
+    new_ballots = None
+    df = pd.DataFrame()
+    if on == "candidates":
+        df = profile.df.copy()
+        ranking_cols = [col for col in df.columns if "Ranking_" in col]
+        ballot_values = df[ranking_cols].to_numpy()
+        new_full_rankings = []
+        for i, row in enumerate(ballot_values):
+            ranking = []
+            for cand_set in row:
+                if cand_set == frozenset({"~"}):
+                    continue
+                if len(cand_set) > 1:
+                    raise ValueError(
+                        f"Tied candidates {cand_set} found at ballot {i}."
+                        ' on="candidates" require untied rankings. Use "ballot"'
+                        " instead."
+                    )
+                ranking.append(next(iter(cand_set)))
+
+            new_ranking = transform_ballot_func(ranking)
+            if not isinstance(new_ranking, list):
+                raise TypeError(
+                    f"Transform returned ={type(new_ranking)}. Expected list of candidates."
+                )
+            if not any(
+                isinstance(cand, Candidate) and not isinstance(cand, bool) for cand in new_ranking
+            ):
+                raise TypeError(
+                    f"Transform returned non-string/int candidates: {type(new_ranking)}."
+                )
+
+            if len(new_ranking) > profile.max_ranking_length:
+                raise ValueError(
+                    f"Transform returned {len(new_ranking)} candidates for ballot {i}."
+                    f" Profile's max_ranking_length is {profile.max_ranking_length}."
+                )
+
+            new_full_rankings.append(
+                [
+                    [frozenset({cand}) for cand in new_ranking]
+                    + (profile.max_ranking_length - len(new_ranking)) * [frozenset({"~"})]
+                ]
+            )
+
+        df[ranking_cols] = new_full_rankings
+
+        return RankProfile(
+            candidates=profile.candidates, max_ranking_length=profile.max_ranking_length, df=df
+        )
+
+    elif on == "ballot":
+        new_ballots: list[RankBallot] = []
+        for ballot in profile.ballots:
+            new_ballot = transform_ballot_func(ballot)
+            if not isinstance(new_ballot, RankBallot):
+                raise TypeError(f"Transform returned {type(new_ballot)}. Expected RankBallot.")
+            new_ballots.append(new_ballot)
+
+        return RankProfile(
+            ballots=new_ballots,
+            candidates=profile.candidates,
+            max_ranking_length=profile.max_ranking_length,
+        )
+    else:
+        raise ValueError("Transform function can only be applied on ballots or list of canidates.")
+
+
+def replace_ballot_type(
+    profile: RankProfile,
+    original_ballot: Sequence[Candidate] | RankBallot,
+    new_ballot: Sequence[Candidate] | RankBallot,
+) -> RankProfile:
+    return RankProfile()
+
+
+def swap_candidates(
+    profile: RankProfile,
+    left_candidate: Candidate | Sequence[Candidate],
+    right_candidate: Candidate | Sequence[Candidate],
+) -> RankProfile:
+    return RankProfile()
+
+
+def remove_candidate(profile: RankProfile, removed: Candidate | Sequence[Candidate]) -> RankProfile:
+    return RankProfile()


### PR DESCRIPTION
Closes #340
Opening to discuss API and architecture decisions before polishing. See "Design discussion" below.

## Summary

Adds a module-level utility that applies a user-defined function to every ballot in a `RankProfile`.

```python
new_profile = transform_ballots_profile(profile, my_transform_func)
```

The user's function receives either a full `RankBallot` or a plain `list[Candidate]` (the ranking, unwrapped), controlled by an explicit `on` parameter, and returns the same to produce the transformed profile.

## API

```python
def transform_ballots_profile(
    profile: RankProfile,
    transform_ballot_func: Callable[[RankBallot | list[Candidate]], RankBallot | list[Candidate]],
    on: Literal["candidates", "ballot"] = "ballot",
    group_ballots: bool = True,
) -> RankProfile
```

- **`on="ballot"` (default):** the function receives a `RankBallot`. Fully general — handles ties, weights, and anything else on the ballot.
- **`on="candidates"`:** the function receives the ranking as a flat `list[Candidate]` — the friendliest form for common transforms like swapping two candidates. Requires untied rankings; raises `ValueError` (identifying the offending ballot) if the profile contains a tie.
- **`group_ballots=True`:** condenses identical ballot types before applying the function, so the function is called once per *unique* ballot type rather than once per ballot. On real CVR data, unique types are typically a small fraction of total ballots, so this is the main performance lever. Must be set to `False` for stochastic/sampled transforms — see "Performance and correctness notes."

Design choices worth flagging for review:

- **Module-level function, not an instance method.** Follows the cleaning module's organization and keeps `PreferenceProfile`'s surface focused. The issue sketches `pref_profile.transform(...)` — happy to add a thin wrapper method on the class if that's preferred; all logic would stay in the module either way.
- **No `in_place` parameter.** The issue sketches `in_place=False` as the default; this draft omits the parameter entirely. True in-place mutation requires invalidating cached derived state on the profile and complicates every future mutating path. Can be added later if there's demand.
- **No provenance tracking.** Unlike `CleanedProfile`, the returned profile does not record its parent or which ballots changed. Transform and clean are related, so worth deciding whether they should converge.

## Behavior details

- **Validation is per-ballot and fail-fast.** Tied cells in `candidates` mode and over-length returned rankings raise immediately with the ballot index and offending content in the message, before further work is done.
- **Weights are preserved per ballot type** and ride through the transform untouched. Only rankings are modified.
- **Return normalization (`candidates` mode):** returned candidates are re-wrapped into singleton frozensets and padded to `max_ranking_length`.
- **Open: `None`/empty returns.** Current draft treats them as an empty ranking; an alternative is drop the ballot.
- **Open: regrouping after transform.** A transform can map two previously distinct ballot types onto the same ranking, leaving the output with duplicate rows whose weights are not combined. Current draft does not regroup and documents this; the alternative is to condense the result by default.. Leaning toward regrouping by default.

## Performance and correctness notes

Making an *arbitrary* user-defined transform fast is fundamentally limited: the function's logic is opaque to the library, so it must be called from a Python loop — no vectorization is possible. The design accepts this and tries to pull remaining levers:

1. **Deduplication (`group_ballots=True`):** the only way to make an opaque function cheaper is to call it fewer times. Grouping first means cost scales with unique ballot types, not total ballots.
2. **Cheap materialization:** `candidates` mode skips `RankBallot` construction and hands the function a plain list, iterating over the underlying array rather than pandas rows.

**Stochastic transforms and grouping do not mix.** With `group_ballots=True`, a probabilistic function (e.g. "swap A and B with probability 0.3") makes one draw per ballot *type* and applies it to the entire aggregated weight — 100 identical ballots all flip or none do, which is a different (wrong) distribution, not just a slower/faster trade-off. Sampled transforms must use `group_ballots=False` on a profile with unit weights. This is documented in the docstring; a `deterministic` flag that makes the contract explicit is an option if reviewers prefer.

## Testing (to-do)

- Identity transform returns an equal profile (both modes)
- Swap transform produces the expected rankings (both modes)
- Tied profile + `candidates` mode raises with the ballot index
- Over-length returned ranking raises with the ballot index
- Weights preserved through transform; grouping combines weights as expected
- (pending resolution of the open questions: `None`-return behavior, regroup behavior)

---

## Future work: predefined (non-opaque) transform functions

This section is the design discussion the draft is really for.

The general callable above is the escape hatch — it can express anything, at Python-loop speed. But most real transforms are drawn from a small vocabulary: swap two candidates, swap two candidates within some rank distance, truncate to top-k, remove a candidate, replace one ballot type with another. For these, we know the *intent*, which changes what's possible:

**1. Wrapper functions (near-term, cheap).** Predefined transforms shipped as ordinary functions that call `transform_ballots_profile` internally:

```python
swap_candidates(profile, "A", "B", max_distance=2, strict_order=True)
swap_rank_positions(profile, 1, 2)
replace_ballot_type(profile, original_ballot= ["A", "B", "C"], new_ballot= ["A", "C", "B"])
remove_candidate_from_ballots(profile, "C")
truncate_ballots_at_position(profile, 5)
truncate_ballots_at_candidate(profile, "A")
```

Can utilize the internal df representation to perform operations with integers and constrain transform to ballots with matching operation.